### PR TITLE
[CE-75] PCIe Memory Write request should not return completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 CONFIG_DIR = configs
 CONFIG ?= 1vcs_4sld.yaml
 
+ifeq ($(shell uname), Darwin)
+	NPROC = $(shell sysctl -n hw.logicalcpu)
+else
+	NPROC = $$(nproc)
+endif
+
 test:
-	poetry run pytest --cov --cov-report=term-missing -n $$(nproc)
+	poetry run pytest --cov --cov-report=term-missing -n $(NPROC)
 	rm -f mem*.bin
 
 lint:

--- a/opencxl/cxl/component/cxl_mem_manager.py
+++ b/opencxl/cxl/component/cxl_mem_manager.py
@@ -16,7 +16,8 @@ from opencxl.cxl.transport.transaction import (
     CxlMemM2SRwDPacket,
     CxlMemMemRdPacket,
     CxlMemMemWrPacket,
-    CxlMemMemDataPacket
+    CxlMemMemDataPacket,
+    CxlMemCmpPacket
 )
 from opencxl.cxl.component.cxl_memory_device_component import CxlMemoryDeviceComponent
 from opencxl.pci.component.packet_processor import PacketProcessor
@@ -65,6 +66,9 @@ class CxlMemManager(PacketProcessor):
         address = mem_wr_packet.get_address()
         data = mem_wr_packet.data
         await self._memory_device_component.write_mem(address, data)
+
+        packet = CxlMemCmpPacket.create()
+        await self._upstream_fifo.target_to_host.put(packet)
 
     async def _process_host_to_target(self):
         logger.debug(self._create_message("Started processing incoming fifo"))

--- a/opencxl/cxl/component/virtual_switch/routers.py
+++ b/opencxl/cxl/component/virtual_switch/routers.py
@@ -146,7 +146,7 @@ class MmioRouter(CxlRouter):
                     await self._send_completion(req_id, tag, data=0)
                 elif mmio_packet.is_mem_write():
                     logger.debug(self._create_message(f"WR: 0x{address:x}[{size}] OOB"))
-                    await self._send_completion(req_id, tag)
+                    # await self._send_completion(req_id, tag) (no need to send completion on write)
                 continue
 
             if target_port >= len(self._downstream_connections):

--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -303,8 +303,6 @@ class CxlRootPortDevice(RunnableComponent):
             logger.debug(message)
         packet = CxlIoMemWrPacket.create(address, size, data)
         await self._downstream_connection.mmio_fifo.host_to_target.put(packet)
-        # packet = await self._downstream_connection.mmio_fifo.target_to_host.get()
-        # assert is_cxl_io_completion_status_sc(packet)
 
     async def read_mmio(
         self, address: int, size: int = 4, verbose: bool = True
@@ -418,11 +416,6 @@ class CxlRootPortDevice(RunnableComponent):
         packet = CxlMemMemWrPacket.create(address, data)
         await self._downstream_connection.cxl_mem_fifo.host_to_target.put(packet)
         try:
-            """
-            async with asyncio.timeout(3):
-                packet = await self._downstream_connection.cxl_mem_fifo.target_to_host.get()
-            assert is_cxl_mem_completion(packet)
-            """
             return address - self._cxl_hpa_base
         except asyncio.exceptions.TimeoutError:
             logger.error(self._create_message("CXL.mem Write: Timed-out"))

--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -195,8 +195,8 @@ class CxlRootPortDevice(RunnableComponent):
         )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+        # packet = await cfg_fifo.target_to_host.get()
+        # check_if_successful_completion(packet)
 
     async def set_subordinate_bus(self, bdf: int, subordinate_bus: int):
         bdf_string = bdf_to_string(bdf)
@@ -216,8 +216,8 @@ class CxlRootPortDevice(RunnableComponent):
         )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+        # packet = await cfg_fifo.target_to_host.get()
+        # check_if_successful_completion(packet)
 
     async def set_memory_base(self, bdf: int, address_base: int):
         bdf_string = bdf_to_string(bdf)
@@ -238,8 +238,8 @@ class CxlRootPortDevice(RunnableComponent):
         )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+        # packet = await cfg_fifo.target_to_host.get()
+        # check_if_successful_completion(packet)
 
     async def set_memory_limit(self, bdf: int, address_limit: int):
         logger.info(
@@ -259,8 +259,8 @@ class CxlRootPortDevice(RunnableComponent):
         )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+        # packet = await cfg_fifo.target_to_host.get()
+        # check_if_successful_completion(packet)
 
     async def set_bar0(self, bdf: int, bar_address: int):
         # TODO: Support 64-bit BAR
@@ -275,8 +275,8 @@ class CxlRootPortDevice(RunnableComponent):
         )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+        # packet = await cfg_fifo.target_to_host.get() (again, no completion on writes)
+        # check_if_successful_completion(packet)
 
     async def get_bar0_size(
         self,
@@ -304,8 +304,8 @@ class CxlRootPortDevice(RunnableComponent):
             logger.debug(message)
         packet = CxlIoMemWrPacket.create(address, size, data)
         await self._downstream_connection.mmio_fifo.host_to_target.put(packet)
-        packet = await self._downstream_connection.mmio_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await self._downstream_connection.mmio_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
     async def read_mmio(
         self, address: int, size: int = 4, verbose: bool = True

--- a/opencxl/pci/component/mmio_manager.py
+++ b/opencxl/pci/component/mmio_manager.py
@@ -162,7 +162,7 @@ class MmioManager(PacketProcessor):
                     logger.debug(self._create_message(f"RD: 0x{address:x}[{size}] OOB"))
                     await self._send_completion(req_id, tag, data=0)
                 elif mem_req_packet.is_mem_write():
-                    await self._send_completion(req_id, tag)
+                    # await self._send_completion(req_id, tag) (no need to send completion on write)
                     logger.debug(self._create_message(f"WR: 0x{address:x}[{size}] OOB"))
                 else:
                     raise Exception("Unknown Mem request packet.")
@@ -174,7 +174,7 @@ class MmioManager(PacketProcessor):
             data = cast(CxlIoMemWrPacket, mem_req_packet).data
             logger.debug(self._create_message(f"WR: 0x{address:x}[{size}]=0x{data:08x}"))
             register.write_bytes(start_offset, end_offset, data)
-            await self._send_completion(req_id, tag)
+            # await self._send_completion(req_id, tag) (also no need to send completion on write)
         elif mem_req_packet.is_mem_read():
             logger.debug(self._create_message(f"RD: 0x{address:x}[{size}]"))
             data = register.read_bytes(start_offset, end_offset)

--- a/tests/test_pci_component_mmio_manager.py
+++ b/tests/test_pci_component_mmio_manager.py
@@ -79,7 +79,6 @@ async def test_mmio_manager_write():
     await mmio_manager._process_host_to_target(run_once=True)
     assert upstream_fifo.host_to_target.qsize() == 0
     bar_entry.register.write_bytes.assert_not_called()
-    # assert upstream_fifo.target_to_host.qsize() == 1
 
     # bar_entry.base_address = 0x1000
     # bar_entry.register = None

--- a/tests/test_pci_device_pci_device.py
+++ b/tests/test_pci_device_pci_device.py
@@ -108,8 +108,8 @@ async def test_pci_device_config_space():
         logger.info("[PyTest] Testing Config Space Type0 Write (BAR)")
         packet = CxlIoCfgWrPacket.create(create_bdf(0, 0, 0), 0x10, 4, 0xFFFFFFFF, is_type0=True)
         await transport_connection.cfg_fifo.host_to_target.put(packet)
-        packet = await transport_connection.cfg_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await transport_connection.cfg_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
         # NOTE: Test Config Space Type0 Read - BAR READ
         logger.info("[PyTest] Testing Config Space Type0 Read (BAR)")
@@ -132,8 +132,8 @@ async def test_pci_device_config_space():
         logger.info("[PyTest] Testing Config Space Type1 Write - Expect UR")
         packet = CxlIoCfgWrPacket.create(create_bdf(0, 0, 0), 0x10, 4, 0xFFFFFFFF, is_type0=False)
         await transport_connection.cfg_fifo.host_to_target.put(packet)
-        packet = await transport_connection.cfg_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_ur(packet)
+        # packet = await transport_connection.cfg_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_ur(packet)
 
     async def wait_test_stop():
         await device.wait_for_ready()
@@ -169,8 +169,8 @@ async def test_pci_device_mmio():
             create_bdf(0, 0, 0), 0x10, 4, value=base_addresss, is_type0=True
         )
         await transport_connection.cfg_fifo.host_to_target.put(packet)
-        packet = await transport_connection.cfg_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await transport_connection.cfg_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
     async def test_mmio(transport_connection: PciConnection):
         logger.info("[PyTest] Accessing MMIO register")
@@ -178,8 +178,8 @@ async def test_pci_device_mmio():
         data = 0xDEADBEEF
         packet = CxlIoMemWrPacket.create(base_addresss, 4, data=data)
         await transport_connection.mmio_fifo.host_to_target.put(packet)
-        packet = await transport_connection.mmio_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await transport_connection.mmio_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
         # NOTE: Confirm 0xDEADBEEF is written
         packet = CxlIoMemRdPacket.create(base_addresss, 4)
@@ -192,14 +192,14 @@ async def test_pci_device_mmio():
         # NOTE: Write OOB (Upper Boundary), Expect No Error
         packet = CxlIoMemWrPacket.create(base_addresss + bar_size, 4, data=data)
         await transport_connection.mmio_fifo.host_to_target.put(packet)
-        packet = await transport_connection.mmio_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await transport_connection.mmio_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
         # NOTE: Write OOB (Lower Boundary), Expect No Error
         packet = CxlIoMemWrPacket.create(base_addresss - 4, 4, data=data)
         await transport_connection.mmio_fifo.host_to_target.put(packet)
-        packet = await transport_connection.mmio_fifo.target_to_host.get()
-        assert is_cxl_io_completion_status_sc(packet)
+        # packet = await transport_connection.mmio_fifo.target_to_host.get()
+        # assert is_cxl_io_completion_status_sc(packet)
 
         # NOTE: Read OOB (Upper Boundary), Expect 0
         packet = CxlIoMemRdPacket.create(base_addresss + bar_size, 4)

--- a/tests/test_pci_device_pci_device.py
+++ b/tests/test_pci_device_pci_device.py
@@ -178,8 +178,6 @@ async def test_pci_device_mmio():
         data = 0xDEADBEEF
         packet = CxlIoMemWrPacket.create(base_addresss, 4, data=data)
         await transport_connection.mmio_fifo.host_to_target.put(packet)
-        # packet = await transport_connection.mmio_fifo.target_to_host.get()
-        # assert is_cxl_io_completion_status_sc(packet)
 
         # NOTE: Confirm 0xDEADBEEF is written
         packet = CxlIoMemRdPacket.create(base_addresss, 4)

--- a/tests/test_pci_device_pci_device.py
+++ b/tests/test_pci_device_pci_device.py
@@ -132,8 +132,8 @@ async def test_pci_device_config_space():
         logger.info("[PyTest] Testing Config Space Type1 Write - Expect UR")
         packet = CxlIoCfgWrPacket.create(create_bdf(0, 0, 0), 0x10, 4, 0xFFFFFFFF, is_type0=False)
         await transport_connection.cfg_fifo.host_to_target.put(packet)
-        # packet = await transport_connection.cfg_fifo.target_to_host.get()
-        # assert is_cxl_io_completion_status_ur(packet)
+        packet = await transport_connection.cfg_fifo.target_to_host.get()
+        assert is_cxl_io_completion_status_ur(packet)
 
     async def wait_test_stop():
         await device.wait_for_ready()


### PR DESCRIPTION
Previously, PCIe memory write requests/packets would return a dataless completion notification/packet, which does not comply with the CXL.io standard. This change makes it so that memory write requests no longer return a completion. 