### PR TITLE
[CE-144] Support dynamic payload size for structures defined in transaction.py

### DIFF
--- a/opencxl/cxl/component/cxl_packet_processor.py
+++ b/opencxl/cxl/component/cxl_packet_processor.py
@@ -126,7 +126,7 @@ class CxlPacketProcessor(RunnableComponent):
                 if packet.is_cxl_io():
                     cxl_io_packet = cast(CxlIoBasePacket, packet)
                     if cxl_io_packet.is_cpl() or cxl_io_packet.is_cpld():
-                        logger.debug(
+                        logger.info(
                             self._create_message(
                                 f"Received {self._incoming_dir} CXL.io (CPL/CPLD) packet"
                             )
@@ -137,7 +137,7 @@ class CxlPacketProcessor(RunnableComponent):
                         else:
                             await self._incoming.mmio.put(cxl_io_packet)
                     elif cxl_io_packet.is_cfg():
-                        logger.debug(
+                        logger.info(
                             self._create_message(
                                 f"Received {self._incoming_dir} CXL.io (CFG_RD/CFG_WR) packet"
                             )
@@ -145,7 +145,7 @@ class CxlPacketProcessor(RunnableComponent):
                         self._push_tlp_table_entry(cxl_io_packet)
                         await self._incoming.cfg_space.put(cxl_io_packet)
                     elif cxl_io_packet.is_mmio():
-                        logger.debug(
+                        logger.info(
                             self._create_message(
                                 f"Received {self._incoming_dir} CXL.io (MRD/MWR) packet"
                             )
@@ -168,13 +168,13 @@ class CxlPacketProcessor(RunnableComponent):
                     logger.debug(self._create_message(message))
                     raise Exception(message)
             except Exception as e:
-                logger.debug(self._create_message(str(e)))
+                logger.info(self._create_message(str(e)))
                 notification_packet = BaseSidebandPacket.create(
                     SIDEBAND_TYPES.CONNECTION_DISCONNECTED
                 )
                 await self._notify_outgoing_processors(notification_packet)
                 break
-        logger.debug(self._create_message(f"Stopped {self._incoming_dir} packet processor"))
+        logger.info(self._create_message(f"Stopped {self._incoming_dir} packet processor"))
 
     async def _notify_outgoing_processors(self, packet):
         await self._outgoing.cfg_space.put(packet)
@@ -185,22 +185,24 @@ class CxlPacketProcessor(RunnableComponent):
         logger.debug(self._create_message("Starting outgoing CFG FIFO processor"))
         while True:
             packet = await self._outgoing.cfg_space.get()
+            print("GOT", packet.get_pretty_string(), bytes(packet).hex())
             if self._is_disconnection_notification(packet):
                 break
 
             cxl_io_packet = cast(CxlIoBasePacket, packet)
             if cxl_io_packet.is_cpl() or cxl_io_packet.is_cpld():
-                logger.debug(
+                logger.info(
                     self._create_message(f"Received {self._outgoing_dir} CXL.io (CPL/CPLD) packet")
                 )
                 self._pop_tlp_table_entry(cxl_io_packet)
             else:
-                logger.debug(
+                logger.info(
                     self._create_message(
                         f"Received {self._outgoing_dir} CXL.io (CFG_RD/CFG_WR) packet"
                     )
                 )
                 self._push_tlp_table_entry(cxl_io_packet)
+            print(bytes(packet).hex())
             self._writer.write(bytes(packet))
             await self._writer.drain()
         logger.debug(self._create_message("Stopped outgoing CFG FIFO processor"))

--- a/opencxl/cxl/component/packet_reader.py
+++ b/opencxl/cxl/component/packet_reader.py
@@ -55,10 +55,10 @@ class PacketReader(LabeledComponent):
         except Exception as e:
             logger.debug(self._create_message(str(e)))
             if str(e) != "Connection disconnected":
-                logger.debug(traceback.format_exc())
+                logger.info(traceback.format_exc())
             raise Exception("PacketReader is aborted") from e
         except CancelledError as exc:
-            logger.debug(self._create_message("Aborted"))
+            logger.info(self._create_message("Aborted"))
             raise Exception("PacketReader is aborted") from exc
         finally:
             self._task = None
@@ -88,8 +88,10 @@ class PacketReader(LabeledComponent):
     async def _get_payload(self) -> Tuple[BasePacket, bytes]:
         logger.debug(self._create_message("Waiting Packet"))
         header_load = await self._read_payload(BasePacket.get_size())
+        print("[?]", header_load.hex())
         base_packet = BasePacket()
         base_packet.reset(header_load)
+        logger.info(bytes(base_packet.system_header).hex())
         remaining_length = base_packet.system_header.payload_length - len(base_packet)
         if remaining_length < 0:
             raise Exception("remaining length is less than 0")

--- a/opencxl/cxl/component/switch_connection_manager.py
+++ b/opencxl/cxl/component/switch_connection_manager.py
@@ -73,6 +73,7 @@ class SwitchConnectionManager(RunnableComponent):
 
     async def _run(self):
         try:
+            logger.debug(self._create_message("Hello"))
             logger.info(self._create_message("Creating TCP server"))
             server = await self._create_server()
             self._server_task = asyncio.create_task(server.serve_forever())
@@ -138,9 +139,9 @@ class SwitchConnectionManager(RunnableComponent):
             logger.warning(self._create_message(str(e)))
 
         if port_index is None:
-            logger.info(self._create_message("Closed connnection"))
+            logger.info(self._create_message("Closed connection"))
         else:
-            logger.info(self._create_message(f"Closed connnection for port {port_index}"))
+            logger.info(self._create_message(f"Closed connection for port {port_index}"))
 
     async def _send_confirmation(self, writer: asyncio.StreamWriter):
         sideband_response = BaseSidebandPacket.create(SIDEBAND_TYPES.CONNECTION_ACCEPT)

--- a/opencxl/cxl/component/switch_connection_manager.py
+++ b/opencxl/cxl/component/switch_connection_manager.py
@@ -73,7 +73,6 @@ class SwitchConnectionManager(RunnableComponent):
 
     async def _run(self):
         try:
-            logger.debug(self._create_message("Hello"))
             logger.info(self._create_message("Creating TCP server"))
             server = await self._create_server()
             self._server_task = asyncio.create_task(server.serve_forever())

--- a/opencxl/cxl/component/virtual_switch/routers.py
+++ b/opencxl/cxl/component/virtual_switch/routers.py
@@ -143,7 +143,7 @@ class MmioRouter(CxlRouter):
             if target_port is None:
                 if mmio_packet.is_mem_read():
                     logger.debug(self._create_message(f"RD: 0x{address:x}[{size}] OOB"))
-                    await self._send_completion(req_id, tag, data=0)
+                    await self._send_completion(req_id, tag, data=0, data_width=size)
                 elif mmio_packet.is_mem_write():
                     logger.debug(self._create_message(f"WR: 0x{address:x}[{size}] OOB"))
                 continue
@@ -161,9 +161,12 @@ class MmioRouter(CxlRouter):
                 break
             await self._upstream_connection.target_to_host.put(packet)
 
-    async def _send_completion(self, req_id, tag, data: int = None):
+    async def _send_completion(self, req_id, tag, data: int = None, data_width: int = 0):
+        """
+        Note that data_width should be in bytes.
+        """
         if data is not None:
-            packet = CxlIoCompletionWithDataPacket.create(req_id, tag, data)
+            packet = CxlIoCompletionWithDataPacket.create(req_id, tag, data, pload_width=data_width)
         else:
             packet = CxlIoCompletionPacket.create(req_id, tag)
         await self._upstream_connection.target_to_host.put(packet)

--- a/opencxl/cxl/component/virtual_switch/routers.py
+++ b/opencxl/cxl/component/virtual_switch/routers.py
@@ -143,7 +143,7 @@ class MmioRouter(CxlRouter):
             if target_port is None:
                 if mmio_packet.is_mem_read():
                     logger.debug(self._create_message(f"RD: 0x{address:x}[{size}] OOB"))
-                    await self._send_completion(req_id, tag, data=0, data_width=size)
+                    await self._send_completion(req_id, tag, data=0, data_len=size)
                 elif mmio_packet.is_mem_write():
                     logger.debug(self._create_message(f"WR: 0x{address:x}[{size}] OOB"))
                 continue
@@ -161,12 +161,12 @@ class MmioRouter(CxlRouter):
                 break
             await self._upstream_connection.target_to_host.put(packet)
 
-    async def _send_completion(self, req_id, tag, data: int = None, data_width: int = 0):
+    async def _send_completion(self, req_id, tag, data: int = None, data_len: int = 0):
         """
         Note that data_width should be in bytes.
         """
         if data is not None:
-            packet = CxlIoCompletionWithDataPacket.create(req_id, tag, data, pload_width=data_width)
+            packet = CxlIoCompletionWithDataPacket.create(req_id, tag, data, pload_width=data_len)
         else:
             packet = CxlIoCompletionPacket.create(req_id, tag)
         await self._upstream_connection.target_to_host.put(packet)

--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -273,9 +273,12 @@ class CxlRootPortDevice(RunnableComponent):
             bar_address,
             is_type0=is_type0,
         )
+        logger.info(self._create_message("made packet"))
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
+        logger.info(self._create_message("put packet"))
         packet = await cfg_fifo.target_to_host.get()
+        logger.info(self._create_message("got (supposedly) cpl packet"))
         check_if_successful_completion(packet)
 
     async def get_bar0_size(
@@ -286,6 +289,9 @@ class CxlRootPortDevice(RunnableComponent):
         bus = extract_bus_from_bdf(bdf)
         is_type0 = bus == self._secondary_bus
         packet = CxlIoCfgRdPacket.create(bdf, BAR_OFFSETS.BAR0, BAR_REGISTER_SIZE, is_type0)
+        logger.info(
+            self._create_message("Created packet to get bar0 size")
+        )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
         packet = await cfg_fifo.target_to_host.get()
@@ -337,15 +343,34 @@ class CxlRootPortDevice(RunnableComponent):
         bus = extract_bus_from_bdf(bdf)
         is_type0 = bus == self._secondary_bus
         packet = CxlIoCfgRdPacket.create(bdf, cfg_addr, size, is_type0)
+        logger.info(
+            self._create_message("Created packet to get config data")
+        )
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
+        logger.info(
+            self._create_message("Done waiting (1)")
+        )
         packet = await cfg_fifo.target_to_host.get()
+        logger.info(
+            self._create_message("Done waiting (2)")
+        )
         base_packet = cast(BasePacket, packet)
         return self._get_cxl_io_completion_data(base_packet)
 
     async def read_vid_did(self, bdf: int) -> Optional[int]:
+
+        logger.info(
+            self._create_message("read vid, did")
+        )
+
         vid = await self.read_config(bdf, REG_ADDR.VENDOR_ID.START, REG_ADDR.VENDOR_ID.LEN)
         did = await self.read_config(bdf, REG_ADDR.DEVICE_ID.START, REG_ADDR.DEVICE_ID.LEN)
+        
+        logger.info(
+            self._create_message("read vid, did --- done waiting")
+        )
+
         if did is None or vid is None:
             return None
         return (did << 16) | vid
@@ -606,7 +631,11 @@ class CxlRootPortDevice(RunnableComponent):
     ) -> List[DeviceEnumerationInfo]:
         bdf_list = generate_bdfs_for_bus(bus)
         devices: List[DeviceEnumerationInfo] = []
-
+    
+        logger.info(
+            self._create_message("scan buses")
+        )
+        
         for bdf in bdf_list:
             vid_did = await self.read_vid_did(bdf)
             if vid_did is None:
@@ -679,7 +708,11 @@ class CxlRootPortDevice(RunnableComponent):
                 await self.scan_pci_capabilities(bdf, info.capabilities)
                 await self.scan_component_registers(info)
                 devices.append(info)
-
+    
+        logger.info(
+            self._create_message("set buses --- finished")
+        )
+        
         return devices
 
     async def scan_devices(self) -> EnumerationInfo:
@@ -745,6 +778,10 @@ class CxlRootPortDevice(RunnableComponent):
 
         await self.set_secondary_bus(usp_bdf, next_bus)
         await self.set_subordinate_bus(usp_bdf, next_bus)
+ 
+        logger.info(
+            self._create_message("set buses")
+        )
 
         for dsp_bdf in generate_bdfs_for_bus(next_bus):
             # --------------------------------------------------

--- a/opencxl/cxl/transport/transaction.py
+++ b/opencxl/cxl/transport/transaction.py
@@ -13,7 +13,7 @@ from opencxl.util.unaligned_bit_structure import (
     UnalignedBitStructure,
     BitField,
     ByteField,
-    DynamicByteFieldSpawner,
+    DynamicByteField,
     StructureField,
 )
 from opencxl.util.pci import (
@@ -320,7 +320,7 @@ class CxlIoMemWrPacket(CxlIoMemReqPacket):
     data: int
     # TODO: Support dynamic data size. Fixed to 8 for now.
     _fields = CxlIoMemReqPacket._fields + [
-        DynamicByteFieldSpawner("data", CXL_IO_MREQ_FIELD_START, 0x0),
+        DynamicByteField("data", CXL_IO_MREQ_FIELD_START, 0x0),
     ]
 
     @staticmethod
@@ -592,7 +592,7 @@ class CxlIoCompletionWithDataPacket(CxlIoBasePacket):
             CXL_IO_CPL_HEADER_END,
             CxlIoCompletionHeader,
         ),
-        DynamicByteFieldSpawner("data", CXL_IO_CPL_FIELD_START, 0x0),
+        DynamicByteField("data", CXL_IO_CPL_FIELD_START, 0x0),
     ]
 
     @staticmethod

--- a/opencxl/pci/component/config_space_manager.py
+++ b/opencxl/pci/component/config_space_manager.py
@@ -107,7 +107,7 @@ class ConfigSpaceManager(RunnableComponent):
         )
         value = self._register.read_bytes(cfg_addr, cfg_addr + size - 1)
 
-        completion_packet = CxlIoCompletionWithDataPacket.create(req_id, tag, value)
+        completion_packet = CxlIoCompletionWithDataPacket.create(req_id, tag, value, pload_width=size)
         await self._upstream_fifo.target_to_host.put(completion_packet)
 
     async def _process_cxl_io_cfg_wr(self, cfg_wr_packet: CxlIoCfgWrPacket):

--- a/opencxl/pci/component/config_space_manager.py
+++ b/opencxl/pci/component/config_space_manager.py
@@ -112,9 +112,15 @@ class ConfigSpaceManager(RunnableComponent):
         )
 
         completion_packet = CxlIoCompletionWithDataPacket.create(req_id, tag, value)
+        print("asdf", completion_packet.system_header.payload_length)
+        print("~", bytes(completion_packet).hex())
+        print("asdf", completion_packet.system_header.payload_length)
 
+        logger.info(
+            self._create_message(completion_packet.get_pretty_string())
+        )
         await self._upstream_fifo.target_to_host.put(completion_packet)
-
+        print("hex", bytes(completion_packet).hex())
         logger.info(
             self._create_message("Put packet")
         )

--- a/opencxl/pci/component/config_space_manager.py
+++ b/opencxl/pci/component/config_space_manager.py
@@ -102,13 +102,22 @@ class ConfigSpaceManager(RunnableComponent):
 
         # TODO: Fix OOB
 
-        logger.debug(
+        logger.info(
             self._create_message(f"[RD] Config Space - ADDR: 0x{cfg_addr:04x}, SIZE: {size}")
         )
         value = self._register.read_bytes(cfg_addr, cfg_addr + size - 1)
 
-        completion_packet = CxlIoCompletionWithDataPacket.create(req_id, tag, value, pload_width=size)
+        logger.info(
+            self._create_message("Read bytes")
+        )
+
+        completion_packet = CxlIoCompletionWithDataPacket.create(req_id, tag, value)
+
         await self._upstream_fifo.target_to_host.put(completion_packet)
+
+        logger.info(
+            self._create_message("Put packet")
+        )
 
     async def _process_cxl_io_cfg_wr(self, cfg_wr_packet: CxlIoCfgWrPacket):
         # NOTE: All PCIe devices are single function devices.

--- a/opencxl/pci/component/mmio_manager.py
+++ b/opencxl/pci/component/mmio_manager.py
@@ -134,7 +134,8 @@ class MmioManager(PacketProcessor):
 
     async def _send_completion(self, req_id: int, tag: int, data: int = None, data_width: int = 0):
         if data is not None:
-            if data >= (1 << (data_width * 8)):
+            if isinstance(data, int) and data >= (1 << (data_width * 8)):
+                # if isinstance(data, MagicMock), then just assume it'll fit in the given size
                 raise Exception(
                     f"'Data: {data} could not possibly fit within width: {data_width}"
                 )

--- a/opencxl/util/component.py
+++ b/opencxl/util/component.py
@@ -11,7 +11,7 @@ from asyncio import create_task, gather, Condition
 from typing import Optional
 from opencxl.util.logger import logger
 import traceback
-
+import time
 
 class COMPONENT_STATUS(Enum):
     STOPPED = auto()
@@ -25,11 +25,12 @@ class LabeledComponent:
         self._label = label
 
     def _create_message(self, message):
+        ret_message = f"[{time.time():.4f}] "
         if self._label:
-            message = f"[{self.__class__.__name__}:{self._label}] {message}"
+            ret_message += f"[{self.__class__.__name__}:{self._label}] {message}"
         else:
-            message = f"[{self.__class__.__name__}] {message}"
-        return message
+            ret_message += f"[{self.__class__.__name__}] {message}"
+        return ret_message
 
 
 class RunnableComponent(LabeledComponent):

--- a/opencxl/util/number.py
+++ b/opencxl/util/number.py
@@ -106,3 +106,40 @@ def tlptoh64(n):
     if sys.byteorder == "big":
         return n
     return bswap64(n)
+
+def extract_upper(from_what: int, how_much: int, how_long: int):
+    """
+    Extracts and returns the upper `how_much` bits from `from_what`.
+    `from_what` is assumed to be `how_long` bits wide.
+    If `from_what` could not possibly be `how_long` bits wide, 
+    ValueError is raised.
+    If `how_much > how_long`, then for obvious reasons ValueError
+    is raised again.
+    Ex. `extract_upper(0b1101010010, 5, 12) == 0b00110`.
+    `extract_upper(0b10000010, 1, 2) -> ValueError` 
+    """
+    if from_what >= (1 << how_long):
+        raise ValueError(f"{from_what} does not fit within a width of {how_long} bits.")
+    if how_much > how_long:
+        raise ValueError(f"It does not make sense that {how_much} (how_much) > {how_long} (how_long)")
+    full_mask = (1 << how_long) - 1
+    b_mask = (1 << (how_long - how_much)) - 1
+    b_mask = (~b_mask) & full_mask
+    return (from_what & b_mask) >> (how_long - how_much)
+
+def extract_lower(from_what: int, how_much: int, how_long: int):
+    """
+    Extracts and returns the lower `how_much` bits from `from_what`.
+    `from_what` is assumed to be `how_long` bits wide.
+    If `from_what` could not possibly be `how_long` bits wide, 
+    ValueError is raised.
+    If `how_much > how_long`, then for obvious reasons ValueError
+    is raised again.
+    Ex. `extract_upper(0b1101010010, 5, 12) == 0b10010`.
+    `extract_upper(0b10000010, 1, 2) -> ValueError` 
+    """
+    if from_what >= (1 << how_long):
+        raise ValueError(f"{from_what} does not fit within a width of {how_long} bits.")
+    if how_much > how_long:
+        raise ValueError(f"It does not make sense that {how_much} (how_much) > {how_long} (how_long)")
+    return ((1 << how_much) - 1) & from_what

--- a/opencxl/util/unaligned_bit_structure.py
+++ b/opencxl/util/unaligned_bit_structure.py
@@ -183,7 +183,7 @@ class ShareableByteArray:
             self._data.extend(bytearray([0] * (new_size - self.size)))
         # truncation
         else:
-            self._data = self._data[0 : new_size]
+            self._data = self._data[:new_size]
         self.size = new_size
 
     def get_hex_dump(self, line_length: int = 16):
@@ -334,7 +334,7 @@ class UnalignedBitStructure:
             elif type(field) == StructureField:
                 self._add_structured_field(field)
 
-    def _check_if_fields_are_valid(self) -> bool:
+    def _check_if_fields_are_valid(self):
         fields = self._fields
         bit_fields = 0
         byte_fields = 0
@@ -400,8 +400,6 @@ class UnalignedBitStructure:
             self._last_offset = last_offset / BITS_IN_BYTE
         else:
             self._last_offset = last_offset
-
-        return True
 
     @staticmethod
     def ascii_str_to_int(ascii_str: str, length: int) -> int:

--- a/opencxl/util/unaligned_bit_structure.py
+++ b/opencxl/util/unaligned_bit_structure.py
@@ -715,6 +715,8 @@ class BitMaskedBitStructure(UnalignedBitStructure):
 
         selected_field = None
         for field in self._fields:
+            if type(field) == DynamicByteField:
+                continue
             if field.start <= offset and offset <= field.end:
                 selected_field = field
                 break

--- a/tests/test_cxl_component_switch_connection_manager.py.rej
+++ b/tests/test_cxl_component_switch_connection_manager.py.rej
@@ -1,0 +1,8 @@
+diff a/tests/test_cxl_component_switch_connection_manager.py b/tests/test_cxl_component_switch_connection_manager.py	(rejected hunks)
+@@ -28,7 +28,6 @@ from opencxl.cxl.transport.transaction import (
+     CxlIoCfgWrPacket,
+     CxlIoMemRdPacket,
+     CxlIoMemWrPacket,
+     CxlIoCompletionWithDataPacket,
+     CxlMemMemRdPacket,
+     CxlMemMemWrPacket,

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -287,12 +287,16 @@ async def test_cxl_host_ete():
         memory_file=f"mem{switch_port}.bin",
         port=switch_port,
     )
+    
+    print("A" * 20)
 
     host_manager = CxlHostManager(host_port=host_port, util_port=util_port)
     host = CxlHost(port_index=0, switch_port=switch_port, host_port=host_port)
     test_mode_host = CxlHost(
         port_index=2, switch_port=switch_port, host_port=host_port, test_mode=True
     )
+
+    print("B" * 20)
 
     start_tasks = [
         asyncio.create_task(host.run()),
@@ -311,6 +315,8 @@ async def test_cxl_host_ete():
         asyncio.create_task(sld.wait_for_ready()),
     ]
     await asyncio.gather(*wait_tasks)
+    
+    print("C" * 20)
 
     data = 0xA5A5
     valid_addr = 0x40
@@ -325,6 +331,8 @@ async def test_cxl_host_ete():
         asyncio.create_task(test_mode_host._reinit(invalid_addr)),
     ]
     await asyncio.gather(*test_tasks)
+    
+    print("D" * 20)
 
     stop_tasks = [
         asyncio.create_task(sw_conn_manager.stop()),

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -263,6 +263,7 @@ async def test_cxl_host_util_client():
 @pytest.mark.asyncio
 async def test_cxl_host_ete():
     # pylint: disable=protected-access
+    print("!" * 20)
     host_port = BASE_TEST_PORT + pytest.PORT.TEST_5
     util_port = BASE_TEST_PORT + pytest.PORT.TEST_5 + 50
     switch_port = BASE_TEST_PORT + pytest.PORT.TEST_5 + 51
@@ -275,6 +276,8 @@ async def test_cxl_host_ete():
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=sw_conn_manager, port_configs=port_configs
     )
+    print("Z" * 20)
+
     switch_configs = [
         VirtualSwitchConfig(upstream_port_index=0, vppb_counts=1, initial_bounds=[1])
     ]
@@ -306,6 +309,8 @@ async def test_cxl_host_ete():
         asyncio.create_task(virtual_switch_manager.run()),
         asyncio.create_task(sld.run()),
     ]
+
+    print("^" * 20)
     wait_tasks = [
         asyncio.create_task(sw_conn_manager.wait_for_ready()),
         asyncio.create_task(physical_port_manager.wait_for_ready()),
@@ -315,7 +320,7 @@ async def test_cxl_host_ete():
         asyncio.create_task(sld.wait_for_ready()),
     ]
     await asyncio.gather(*wait_tasks)
-    
+ 
     print("C" * 20)
 
     data = 0xA5A5

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -263,7 +263,6 @@ async def test_cxl_host_util_client():
 @pytest.mark.asyncio
 async def test_cxl_host_ete():
     # pylint: disable=protected-access
-    print("!" * 20)
     host_port = BASE_TEST_PORT + pytest.PORT.TEST_5
     util_port = BASE_TEST_PORT + pytest.PORT.TEST_5 + 50
     switch_port = BASE_TEST_PORT + pytest.PORT.TEST_5 + 51
@@ -276,7 +275,6 @@ async def test_cxl_host_ete():
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=sw_conn_manager, port_configs=port_configs
     )
-    print("Z" * 20)
 
     switch_configs = [
         VirtualSwitchConfig(upstream_port_index=0, vppb_counts=1, initial_bounds=[1])
@@ -290,16 +288,12 @@ async def test_cxl_host_ete():
         memory_file=f"mem{switch_port}.bin",
         port=switch_port,
     )
-    
-    print("A" * 20)
 
     host_manager = CxlHostManager(host_port=host_port, util_port=util_port)
     host = CxlHost(port_index=0, switch_port=switch_port, host_port=host_port)
     test_mode_host = CxlHost(
         port_index=2, switch_port=switch_port, host_port=host_port, test_mode=True
     )
-
-    print("B" * 20)
 
     start_tasks = [
         asyncio.create_task(host.run()),
@@ -310,7 +304,6 @@ async def test_cxl_host_ete():
         asyncio.create_task(sld.run()),
     ]
 
-    print("^" * 20)
     wait_tasks = [
         asyncio.create_task(sw_conn_manager.wait_for_ready()),
         asyncio.create_task(physical_port_manager.wait_for_ready()),
@@ -320,8 +313,6 @@ async def test_cxl_host_ete():
         asyncio.create_task(sld.wait_for_ready()),
     ]
     await asyncio.gather(*wait_tasks)
- 
-    print("C" * 20)
 
     data = 0xA5A5
     valid_addr = 0x40
@@ -336,8 +327,6 @@ async def test_cxl_host_ete():
         asyncio.create_task(test_mode_host._reinit(invalid_addr)),
     ]
     await asyncio.gather(*test_tasks)
-    
-    print("D" * 20)
 
     stop_tasks = [
         asyncio.create_task(sw_conn_manager.stop()),

--- a/tests/test_dynamic_fields.py
+++ b/tests/test_dynamic_fields.py
@@ -8,7 +8,7 @@
 from opencxl.util.unaligned_bit_structure import (
     UnalignedBitStructure,
     ByteField,
-    DynamicByteFieldSpawner,
+    DynamicByteField,
 )
 
 from opencxl.cxl.transport.transaction import (
@@ -24,7 +24,7 @@ class DynamicByteStructure(UnalignedBitStructure):
         ByteField("field1", 0, 0),  # 1 Byte
         ByteField("field2", 1, 2),  # 2 Bytes
         ByteField("field3", 3, 5),  # 3 Bytes
-        DynamicByteFieldSpawner("payload", 6, 0)
+        DynamicByteField("payload", 6, 0)
     ]
 
 def test_basic_dbf():

--- a/tests/test_dynamic_fields.py
+++ b/tests/test_dynamic_fields.py
@@ -1,0 +1,29 @@
+"""
+ Copyright (c) 2024, Eeum, Inc.
+
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+from opencxl.util.unaligned_bit_structure import (
+    UnalignedBitStructure,
+    BitField,
+    ByteField,
+    DynamicByteField,
+    StructureField,
+)
+
+class DynamicByteStructure:
+    field1: int
+    field2: int
+    field3: int
+    payload: int
+    _fields = [
+        ByteField("field1", 0, 0),  # 1 Byte
+        ByteField("field2", 1, 2),  # 2 Bytes
+        ByteField("field3", 3, 5),  # 3 Bytes
+        DynamicByteField("payload", 6, 4),  # 4 Bytes
+    ]
+
+def test_basic_dbf():
+    pass

--- a/tests/test_dynamic_fields.py
+++ b/tests/test_dynamic_fields.py
@@ -13,7 +13,17 @@ from opencxl.util.unaligned_bit_structure import (
     StructureField,
 )
 
-class DynamicByteStructure:
+from opencxl.cxl.transport.transaction import (
+    CxlIoCfgRdPacket,
+    CxlIoCfgWrPacket,
+    CxlIoMemRdPacket,
+    CxlIoMemWrPacket,
+    CxlIoCompletionWithDataPacket,
+    is_cxl_io_completion_status_sc,
+    is_cxl_io_completion_status_ur,
+)
+
+class DynamicByteStructure(UnalignedBitStructure):
     field1: int
     field2: int
     field3: int
@@ -22,8 +32,37 @@ class DynamicByteStructure:
         ByteField("field1", 0, 0),  # 1 Byte
         ByteField("field2", 1, 2),  # 2 Bytes
         ByteField("field3", 3, 5),  # 3 Bytes
-        DynamicByteField("payload", 6, 4),  # 4 Bytes
+        DynamicByteField("payload", 6, 0)
     ]
 
 def test_basic_dbf():
-    pass
+    pckt = bytes([35, 25, 85, 90, 15, 100, 200, 210, 95])
+    DBS = DynamicByteStructure()
+    DBS.reset(pckt)
+    assert DBS.field1 == 0x23
+    assert DBS.field2 == 0x5519
+    assert DBS.field3 == 0x640f5a
+    assert DBS.payload == 0x5fd2c8
+    assert len(DBS) == len(pckt)
+    print(bytes(DBS).hex())
+
+    pckt2 = bytes([1, 1, 1, 1, 1, 1, 2, 3])
+    DBS.reset(pckt2)
+    assert DBS.field3 == 0x10101
+    assert DBS.payload == 0x302
+    assert len(DBS) == len(pckt2)
+    print(bytes(DBS).hex())
+
+    pckt3 = bytes([1, 1, 1, 1, 1, 1, 8, 16, 24, 32, 110, 251])
+    DBS.reset(pckt3)
+    assert DBS.field3 == 0x10101
+    assert DBS.payload == 0xfb6e20181008
+    assert len(DBS) == len(pckt3)
+    print(bytes(DBS).hex())
+
+def test_io_mem_wr():
+    addr = 0x0
+    data = 0xDEADBEEF
+    packet = CxlIoMemWrPacket.create(addr, 4, data=data)
+    assert packet.data == data
+

--- a/tests/test_dynamic_fields.py
+++ b/tests/test_dynamic_fields.py
@@ -7,20 +7,12 @@
 
 from opencxl.util.unaligned_bit_structure import (
     UnalignedBitStructure,
-    BitField,
     ByteField,
-    DynamicByteField,
-    StructureField,
+    DynamicByteFieldSpawner,
 )
 
 from opencxl.cxl.transport.transaction import (
-    CxlIoCfgRdPacket,
-    CxlIoCfgWrPacket,
-    CxlIoMemRdPacket,
     CxlIoMemWrPacket,
-    CxlIoCompletionWithDataPacket,
-    is_cxl_io_completion_status_sc,
-    is_cxl_io_completion_status_ur,
 )
 
 class DynamicByteStructure(UnalignedBitStructure):
@@ -32,7 +24,7 @@ class DynamicByteStructure(UnalignedBitStructure):
         ByteField("field1", 0, 0),  # 1 Byte
         ByteField("field2", 1, 2),  # 2 Bytes
         ByteField("field3", 3, 5),  # 3 Bytes
-        DynamicByteField("payload", 6, 0)
+        DynamicByteFieldSpawner("payload", 6, 0)
     ]
 
 def test_basic_dbf():
@@ -65,4 +57,3 @@ def test_io_mem_wr():
     data = 0xDEADBEEF
     packet = CxlIoMemWrPacket.create(addr, 4, data=data)
     assert packet.data == data
-


### PR DESCRIPTION
Accomplished via two new classes (in `unaligned_bit_structure.py`): `DynamicByteField` and `DynamicByteFieldInstance`. Specify `DynamicByteField` in `_fields` if you want the class to support a dynamically-sized payload (or byte field in general). A class can only have one `DynamicByteField`, and it *must* be the last field in the class (i.e. no field can come after it).

Internally, `DynamicByteField`s are used to generate `DynamicByteFieldInstances`s, "smart" resizing fields capable of serializing to byte fields of any length. They are used to implement dynamically-sized payloads in `CxlIoMemWr` and `CxlIoCompletionWithData` packets. There is no limit to the width of a `DynamicByteFieldInstance`. 

Since different instances of dynamically-sized packet classes may differ in size (ex. one `CxlIoMemWr` instance could have a payload of 40 bytes, while another could have a payload of 200), the developer should *never* specify `DynamicByteFieldInstance` in the `_fields` field of any class. Instead, they should specify a `DynamicByteField` with default values of their choice, which as stated above will then act as a "factory" that creates new, *distinct*, *independent* `DynamicByteFieldInstance`s. If the developer does not do this, the resulting side-effects can cause some major headaches while debugging!

Apart from the addition of `DynamicByteField` and `DynamicByteFieldInstance`, some changes have been made to logging in order to ease debugging---most notably, exceptions thrown during a run of the emulator are printed at `INFO` level rather than `DEBUG` level.