### PR TITLE
[#45] Fixed Config space read/write packet handling

### DIFF
--- a/opencxl/cxl/component/virtual_switch/routers.py
+++ b/opencxl/cxl/component/virtual_switch/routers.py
@@ -131,12 +131,8 @@ class MmioRouter(CxlRouter):
                 raise Exception(f"Received unexpected packet: {base_packet.get_type()}")
 
             mmio_packet = cast(CxlIoMemReqPacket, packet)
-            addr_upper = mmio_packet.mreq_header.addr_upper << 8
-            addr_lower = mmio_packet.mreq_header.addr_lower << 2
-            address = tlptoh64(addr_upper | addr_lower)
-            size = (mmio_packet.cxl_io_header.length_upper << 8) | (
-                mmio_packet.cxl_io_header.length_lower & 0xFF
-            )
+            address = mmio_packet.get_address()
+            size = mmio_packet.get_data_size()
             req_id = tlptoh16(mmio_packet.mreq_header.req_id)
             tag = mmio_packet.mreq_header.tag
             target_port = self._routing_table.get_mmio_target_port(address)

--- a/opencxl/cxl/component/virtual_switch/routers.py
+++ b/opencxl/cxl/component/virtual_switch/routers.py
@@ -12,7 +12,7 @@ from typing import List, cast
 from opencxl.util.logger import logger
 from opencxl.util.component import RunnableComponent
 from opencxl.util.pci import bdf_to_string
-from opencxl.util.number import tlptoh16, tlptoh64
+from opencxl.util.number import tlptoh16
 from opencxl.cxl.component.cxl_connection import CxlConnection, FifoPair
 from opencxl.cxl.component.virtual_switch.routing_table import RoutingTable
 from opencxl.cxl.transport.transaction import (

--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -31,7 +31,6 @@ from opencxl.util.pci import (
 )
 from opencxl.cxl.transport.transaction import (
     BasePacket,
-    CxlIoBasePacket,
     CxlIoCfgRdPacket,
     CxlIoCfgWrPacket,
     CxlIoCompletionPacket,

--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -25,6 +25,7 @@ from opencxl.util.pci import (
     create_bdf,
     extract_bus_from_bdf,
     extract_device_from_bdf,
+    extract_function_from_bdf,
     bdf_to_string,
     generate_bdfs_for_bus,
 )
@@ -33,6 +34,7 @@ from opencxl.cxl.transport.transaction import (
     CxlIoBasePacket,
     CxlIoCfgRdPacket,
     CxlIoCfgWrPacket,
+    CxlIoCompletionPacket,
     CxlIoCompletionWithDataPacket,
     CxlIoMemRdPacket,
     CxlIoMemWrPacket,
@@ -172,127 +174,101 @@ class CxlRootPortDevice(RunnableComponent):
         self._continue = True
         self._test_mode = test_mode
         self._run_fut = None
+        self._next_tag = 0
 
         # set default HPA base address using port index
         self._cxl_hpa_base = 0x100000000000 | (int(label[-1]) << 40)
         self._used_hpa_size = 0
 
-    async def set_secondary_bus(self, bdf: int, secondary_bus: int):
-        bdf_string = bdf_to_string(bdf)
-        logger.info(
-            self._create_message(f"Setting secondary bus of device {bdf_string} to {secondary_bus}")
-        )
+    """
+    Base functions for CFG read/write and MMIO read/write
+    """
+
+    async def write_config(self, bdf: int, offset: int, size: int, value: int):
         bus = extract_bus_from_bdf(bdf)
+        bdf_string = bdf_to_string(bdf)
         is_type0 = bus == self._secondary_bus
+        if is_type0:
+            # NOTE: For non-ARI component, only allow device 0
+            device_num = extract_device_from_bdf(bdf)
+            if device_num != 0:
+                return
+
         packet = CxlIoCfgWrPacket.create(
-            bdf,
-            REG_ADDR.SECONDARY_BUS_NUMBER.START,
-            REG_ADDR.SECONDARY_BUS_NUMBER.LEN,
-            secondary_bus,
-            is_type0=is_type0,
+            bdf, offset, size, value, is_type0, req_id=0, tag=self._next_tag
         )
+        self._next_tag = (self._next_tag + 1) % 256
+
         cfg_fifo = self._downstream_connection.cfg_fifo
         await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
 
-    async def set_subordinate_bus(self, bdf: int, subordinate_bus: int):
-        bdf_string = bdf_to_string(bdf)
-        logger.info(
+        # TODO: Wait for an incoming packet that matchs tag
+        packet = await cfg_fifo.target_to_host.get()
+
+        tpl_type_str = "CFG WR0" if is_type0 else "CFG WR1"
+
+        if not is_cxl_io_completion_status_sc(packet):
+            cpl_packet = cast(CxlIoCompletionPacket, packet)
+            logger.debug(
+                self._create_message(
+                    f"[{bdf_string}] {tpl_type_str} @ 0x{offset:x}[{size}B] : "
+                    + f"Unsuccessful, Status: 0x{cpl_packet.cpl_header.status:x}"
+                )
+            )
+            return
+
+        logger.debug(
             self._create_message(
-                f"Setting subordinate bus of device {bdf_string} to {subordinate_bus}"
+                f"[{bdf_string}] {tpl_type_str} @ 0x{offset:x}[{size}B] : 0x{value:x}"
             )
         )
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        packet = CxlIoCfgWrPacket.create(
-            bdf,
-            REG_ADDR.SUBORDINATE_BUS_NUMBER.START,
-            REG_ADDR.SUBORDINATE_BUS_NUMBER.LEN,
-            subordinate_bus,
-            is_type0=is_type0,
-        )
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
 
-    async def set_memory_base(self, bdf: int, address_base: int):
+    async def read_config(self, bdf: int, offset: int, size: int) -> int:
+        if offset + size > ((offset // 4) + 1) * 4:
+            raise Exception("offset + size out of DWORD boundary")
+
+        bit_mask = (1 << size * 8) - 1
+
+        bus = extract_bus_from_bdf(bdf)
         bdf_string = bdf_to_string(bdf)
-        logger.info(
-            self._create_message(
-                f"Setting memory base of device {bdf_string} to {address_base:08x}"
+        is_type0 = bus == self._secondary_bus
+        if is_type0:
+            # NOTE: For non-ARI component, only allow device 0
+            device_num = extract_device_from_bdf(bdf)
+            if device_num != 0:
+                return 0xFFFFFFFF & bit_mask
+
+        packet = CxlIoCfgRdPacket.create(bdf, offset, size, is_type0, req_id=0, tag=self._next_tag)
+        self._next_tag = (self._next_tag + 1) % 256
+        cfg_fifo = self._downstream_connection.cfg_fifo
+        await cfg_fifo.host_to_target.put(packet)
+
+        # TODO: Wait for an incoming packet that matchs tag
+        packet = await cfg_fifo.target_to_host.get()
+
+        bit_offset = (offset % 4) * 8
+
+        tpl_type_str = "CFG RD0" if is_type0 else "CFG RD1"
+
+        if not is_cxl_io_completion_status_sc(packet):
+            cpl_packet = cast(CxlIoCompletionPacket, packet)
+            logger.debug(
+                self._create_message(
+                    f"[{bdf_string}] {tpl_type_str} @ 0x{offset:x}[{size}B] : "
+                    + f"Unsuccessful, Status: 0x{cpl_packet.cpl_header.status:x}"
+                )
             )
-        )
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        address_base_regval = memory_base_addr_to_regval(address_base)
-        packet = CxlIoCfgWrPacket.create(
-            bdf,
-            REG_ADDR.MEMORY_BASE.START,
-            REG_ADDR.MEMORY_BASE.LEN,
-            address_base_regval,
-            is_type0=is_type0,
-        )
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
-
-    async def set_memory_limit(self, bdf: int, address_limit: int):
-        logger.info(
-            self._create_message(
-                f"Setting memory limit of device {bdf_to_string(bdf)} to {address_limit:08x}"
-            )
-        )
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        address_limit_regval = memory_limit_addr_to_regval(address_limit)
-        packet = CxlIoCfgWrPacket.create(
-            bdf,
-            REG_ADDR.MEMORY_LIMIT.START,
-            REG_ADDR.MEMORY_LIMIT.LEN,
-            address_limit_regval,
-            is_type0=is_type0,
-        )
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
-
-    async def set_bar0(self, bdf: int, bar_address: int):
-        # TODO: Support 64-bit BAR
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        packet = CxlIoCfgWrPacket.create(
-            bdf,
-            BAR_OFFSETS.BAR0,
-            BAR_REGISTER_SIZE,
-            bar_address,
-            is_type0=is_type0,
-        )
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
-
-    async def get_bar0_size(
-        self,
-        bdf: int,
-    ) -> int:
-        # TODO: Support 64-bit BAR
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        packet = CxlIoCfgRdPacket.create(bdf, BAR_OFFSETS.BAR0, BAR_REGISTER_SIZE, is_type0)
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        check_if_successful_completion(packet)
+            return 0xFFFFFFFF & bit_mask
 
         cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
-        if cpld_packet.data == 0:
-            return cpld_packet.data
-        return 0xFFFFFFFF - cpld_packet.data + 1
+        data = (cpld_packet.data >> bit_offset) & bit_mask
+
+        logger.debug(
+            self._create_message(
+                f"[{bdf_string}] {tpl_type_str} @ 0x{offset:x}[{size}B] : 0x{data:x}"
+            )
+        )
+        return data
 
     async def write_mmio(self, address: int, data: int, size: int = 4, verbose: bool = True):
         message = self._create_message(f"MMIO: Writing 0x{data:08x} to 0x{address:08x}")
@@ -317,82 +293,6 @@ class CxlRootPortDevice(RunnableComponent):
         assert is_cxl_io_completion_status_sc(packet)
         cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
         return cpld_packet.data
-
-    def _get_cxl_io_completion_data(self, packet: BasePacket) -> Optional[int]:
-        if not packet.is_cxl_io():
-            raise Exception(f"Received unexpected packet. type: {packet.get_type()}")
-
-        cxl_io_packet = cast(CxlIoBasePacket, packet)
-        if cxl_io_packet.is_cpl():
-            return None
-        if cxl_io_packet.is_cpld():
-            cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
-            return cpld_packet.data
-
-        raise Exception("Received unexpected CXL.io packet")
-
-    async def read_config(self, bdf: int, cfg_addr: int, size: int) -> Optional[int]:
-        bus = extract_bus_from_bdf(bdf)
-        is_type0 = bus == self._secondary_bus
-        packet = CxlIoCfgRdPacket.create(bdf, cfg_addr, size, is_type0)
-        cfg_fifo = self._downstream_connection.cfg_fifo
-        await cfg_fifo.host_to_target.put(packet)
-        packet = await cfg_fifo.target_to_host.get()
-        base_packet = cast(BasePacket, packet)
-        return self._get_cxl_io_completion_data(base_packet)
-
-    async def read_vid_did(self, bdf: int) -> Optional[int]:
-        vid = await self.read_config(bdf, REG_ADDR.VENDOR_ID.START, REG_ADDR.VENDOR_ID.LEN)
-        did = await self.read_config(bdf, REG_ADDR.DEVICE_ID.START, REG_ADDR.DEVICE_ID.LEN)
-        if did is None or vid is None:
-            return None
-        return (did << 16) | vid
-
-    async def read_class_code(self, bdf: int) -> int:
-        data = await self.read_config(bdf, REG_ADDR.CLASS_CODE.START, REG_ADDR.CLASS_CODE.LEN)
-        if data is None:
-            raise Exception("Failed to read class code")
-        return data
-
-    async def read_bar(self, bdf, bar_id) -> int:
-        offset = 0x10 + bar_id * 4
-        size = 4
-        data = await self.read_config(bdf, offset, size=size)
-        if data is None:
-            raise Exception(f"Failed to read bar {bar_id}")
-        return data
-
-    async def read_secondary_bus(self, bdf: int) -> int:
-        data = await self.read_config(
-            bdf,
-            REG_ADDR.SECONDARY_BUS_NUMBER.START,
-            REG_ADDR.SECONDARY_BUS_NUMBER.LEN,
-        )
-        if data is None:
-            raise Exception("Failed to read secondary bus")
-        return data
-
-    async def read_subordinate_bus(self, bdf: int) -> int:
-        data = await self.read_config(
-            bdf,
-            REG_ADDR.SUBORDINATE_BUS_NUMBER.START,
-            REG_ADDR.SUBORDINATE_BUS_NUMBER.LEN,
-        )
-        if data is None:
-            raise Exception("Failed to read subordinate bus")
-        return data
-
-    async def read_memory_base(self, bdf: int) -> int:
-        data = await self.read_config(bdf, REG_ADDR.MEMORY_BASE.START, REG_ADDR.MEMORY_BASE.LEN)
-        if data is None:
-            raise Exception("Failed to read memory base")
-        return data
-
-    async def read_memory_limit(self, bdf: int) -> int:
-        data = await self.read_config(bdf, REG_ADDR.MEMORY_LIMIT.START, REG_ADDR.MEMORY_LIMIT.LEN)
-        if data is None:
-            raise Exception("Failed to read memory limit")
-        return data
 
     async def cxl_mem_read(self, address: int) -> int:
         logger.info(self._create_message(f"CXL.mem Read: HPA addr:0x{address:08x}"))
@@ -423,6 +323,136 @@ class CxlRootPortDevice(RunnableComponent):
             logger.error(self._create_message("CXL.mem Write: Timed-out"))
             return None
 
+    """
+    Helper functions for PCI Config Space access
+    """
+
+    async def set_secondary_bus(self, bdf: int, secondary_bus: int):
+        bdf_string = bdf_to_string(bdf)
+        logger.info(
+            self._create_message(f"Setting secondary bus of device {bdf_string} to {secondary_bus}")
+        )
+        await self.write_config(
+            bdf,
+            REG_ADDR.SECONDARY_BUS_NUMBER.START,
+            REG_ADDR.SECONDARY_BUS_NUMBER.LEN,
+            secondary_bus,
+        )
+
+    async def set_subordinate_bus(self, bdf: int, subordinate_bus: int):
+        bdf_string = bdf_to_string(bdf)
+        logger.info(
+            self._create_message(
+                f"Setting subordinate bus of device {bdf_string} to {subordinate_bus}"
+            )
+        )
+
+        await self.write_config(
+            bdf,
+            REG_ADDR.SUBORDINATE_BUS_NUMBER.START,
+            REG_ADDR.SUBORDINATE_BUS_NUMBER.LEN,
+            subordinate_bus,
+        )
+
+    async def set_memory_base(self, bdf: int, address_base: int):
+        bdf_string = bdf_to_string(bdf)
+        logger.info(
+            self._create_message(
+                f"Setting memory base of device {bdf_string} to {address_base:08x}"
+            )
+        )
+        address_base_regval = memory_base_addr_to_regval(address_base)
+        await self.write_config(
+            bdf,
+            REG_ADDR.MEMORY_BASE.START,
+            REG_ADDR.MEMORY_BASE.LEN,
+            address_base_regval,
+        )
+
+    async def set_memory_limit(self, bdf: int, address_limit: int):
+        logger.info(
+            self._create_message(
+                f"Setting memory limit of device {bdf_to_string(bdf)} to {address_limit:08x}"
+            )
+        )
+        address_limit_regval = memory_limit_addr_to_regval(address_limit)
+        await self.write_config(
+            bdf,
+            REG_ADDR.MEMORY_LIMIT.START,
+            REG_ADDR.MEMORY_LIMIT.LEN,
+            address_limit_regval,
+        )
+
+    async def set_bar0(self, bdf: int, bar_address: int):
+        # TODO: Support 64-bit BAR
+        await self.write_config(bdf, BAR_OFFSETS.BAR0, BAR_REGISTER_SIZE, bar_address)
+
+    async def get_bar0_size(
+        self,
+        bdf: int,
+    ) -> int:
+        # TODO: Support 64-bit BAR
+        data = await self.read_config(bdf, BAR_OFFSETS.BAR0, BAR_REGISTER_SIZE)
+        if data == 0:
+            return data
+        return 0xFFFFFFFF - data + 1
+
+    async def read_vid_did(self, bdf: int) -> Optional[int]:
+        vid = await self.read_config(bdf, REG_ADDR.VENDOR_ID.START, REG_ADDR.VENDOR_ID.LEN)
+        did = await self.read_config(bdf, REG_ADDR.DEVICE_ID.START, REG_ADDR.DEVICE_ID.LEN)
+        logger.debug(self._create_message(f"VID: 0x{vid:x}"))
+        logger.debug(self._create_message(f"DID: 0x{did:x}"))
+        if did == 0xFFFF and vid == 0xFFFF:
+            logger.debug(self._create_message(f"Device not found at {bdf_to_string(bdf)}"))
+            return None
+        return (did << 16) | vid
+
+    async def read_class_code(self, bdf: int) -> int:
+        data = await self.read_config(bdf, REG_ADDR.CLASS_CODE.START, REG_ADDR.CLASS_CODE.LEN)
+        if data == 0xFFFF:
+            raise Exception("Failed to read class code")
+        return data
+
+    async def read_bar(self, bdf, bar_id) -> int:
+        offset = 0x10 + bar_id * 4
+        size = 4
+        data = await self.read_config(bdf, offset, size=size)
+        if data is None:
+            raise Exception(f"Failed to read bar {bar_id}")
+        return data
+
+    async def read_secondary_bus(self, bdf: int) -> int:
+        data = await self.read_config(
+            bdf,
+            REG_ADDR.SECONDARY_BUS_NUMBER.START,
+            REG_ADDR.SECONDARY_BUS_NUMBER.LEN,
+        )
+        if data is None:
+            raise Exception("Failed to read secondary bus")
+        return data
+
+    async def read_subordinate_bus(self, bdf: int) -> int:
+        data = await self.read_config(
+            bdf,
+            REG_ADDR.SUBORDINATE_BUS_NUMBER.START,
+            REG_ADDR.SUBORDINATE_BUS_NUMBER.LEN,
+        )
+        if data == 0xFFFF:
+            raise Exception("Failed to read secondary bus")
+        return data
+
+    async def read_memory_base(self, bdf: int) -> int:
+        data = await self.read_config(bdf, REG_ADDR.MEMORY_BASE.START, REG_ADDR.MEMORY_BASE.LEN)
+        if data == 0xFFFF:
+            raise Exception("Failed to read subordinate bus")
+        return data
+
+    async def read_memory_limit(self, bdf: int) -> int:
+        data = await self.read_config(bdf, REG_ADDR.MEMORY_LIMIT.START, REG_ADDR.MEMORY_LIMIT.LEN)
+        if data == 0xFFFF:
+            raise Exception("Failed to read memory limit")
+        return data
+
     async def check_bar_size_and_set(
         self,
         bdf: int,
@@ -450,6 +480,10 @@ class CxlRootPortDevice(RunnableComponent):
         else:
             await self.set_bar0(bdf, 0)
         return size
+
+    """
+    Device Enumeration functions
+    """
 
     async def scan_dvsec_register_locator(
         self, bdf: int, cap_offset: int, length: int, capabilities: PciCapabilities
@@ -603,10 +637,21 @@ class CxlRootPortDevice(RunnableComponent):
         bdf_list = generate_bdfs_for_bus(bus)
         devices: List[DeviceEnumerationInfo] = []
 
+        multi_function_devices = set()
         for bdf in bdf_list:
+            device_number = extract_device_from_bdf(bdf)
+            function_number = extract_function_from_bdf(bdf)
+
+            if function_number != 0 and device_number not in multi_function_devices:
+                continue
+
             vid_did = await self.read_vid_did(bdf)
             if vid_did is None:
                 continue
+
+            is_multifunction = (await self.read_config(bdf, 0x0E, 1) & 0x80) >> 7
+            if is_multifunction:
+                multi_function_devices.add(device_number)
 
             bar0 = await self.read_bar(bdf, 0)
 

--- a/opencxl/cxl/transport/transaction.py
+++ b/opencxl/cxl/transport/transaction.py
@@ -276,8 +276,8 @@ class CxlIoMReqHeader(UnalignedBitStructure):
     first_dw_be: int
     last_dw_be: int
     addr_upper: int
-    ph: int
     addr_lower: int
+    ph: int
     _fields = [
         BitField("req_id", 0, 15),
         BitField("tag", 16, 23),
@@ -312,22 +312,37 @@ class CxlIoMemReqPacket(CxlIoBasePacket):
         self.system_header.payload_type = PAYLOAD_TYPE.CXL_IO
         self.cxl_io_header.length_upper = length & 0x300
         self.cxl_io_header.length_lower = length & 0xFF
-        # TODO: actual ID to be added
-        self.mreq_header.req_id = htotlp16(get_randbits(16))
+        self.mreq_header.req_id = 0
         self.mreq_header.tag = get_randbits(8)
-        addr = htotlp64(addr)
-        self.mreq_header.addr_upper = addr >> 8
+
+        addr_upper_bytes = (addr >> 8).to_bytes(7, byteorder="big")
+        self.mreq_header.addr_upper = int.from_bytes(addr_upper_bytes, byteorder="little")
         self.mreq_header.addr_lower = (addr & 0xFF) >> 2
 
     def get_transaction_id(self) -> int:
         return self.mreq_header.get_transaction_id()
 
+    def get_address(self) -> int:
+        addr = 0
+        addr_upper_bytes = self.mreq_header.addr_upper.to_bytes(7, byteorder="little")
+        addr |= int.from_bytes(addr_upper_bytes, byteorder="big") << 8
+        addr |= self.mreq_header.addr_lower << 2
+        return addr
+
+    def get_data_size(self) -> int:
+        size = (self.cxl_io_header.length_upper << 8) | (self.cxl_io_header.length_lower & 0xFF)
+        return size * 4
+
 
 class CxlIoMemRdPacket(CxlIoMemReqPacket):
     @staticmethod
     def create(addr: int, length: int, req_id: int = None, tag: int = None) -> "CxlIoMemRdPacket":
+        """
+        `length` field from the TLP header is measured in DWORDs.
+        """
+        length_dword = (length + 3) // 4
         packet = CxlIoMemRdPacket()
-        packet.fill(addr, length)
+        packet.fill(addr, length_dword)
         packet.cxl_io_header.fmt_type = CXL_IO_FMT_TYPE.MRD_64B
         packet.system_header.payload_length = CxlIoMemRdPacket.get_size()
         # override for unit-testing
@@ -349,13 +364,13 @@ class CxlIoMemWrPacket(CxlIoMemReqPacket):
         addr: int, length: int, data: int, req_id: int = None, tag: int = None
     ) -> "CxlIoMemWrPacket":
         """
-        `length` is measured in DWORDs.
+        `length` field from the TLP header is measured in DWORDs.
         """
+        length_dword = (length + 3) // 4
         packet = CxlIoMemWrPacket()
-        packet.fill(addr, length)
+        packet.fill(addr, length_dword)
         packet.cxl_io_header.fmt_type = CXL_IO_FMT_TYPE.MWR_64B
-
-        packet.set_dynamic_field_length(length * 32)
+        packet.set_dynamic_field_length(length)
         packet.data = data
 
         packet.system_header.payload_length = len(packet)
@@ -417,9 +432,8 @@ class CxlIoCfgReqPacket(CxlIoBasePacket):
         self.cxl_io_header.at = 0b00
         self.cxl_io_header.length_upper = 0b00
         self.cxl_io_header.length_lower = 0b00000001
-
-        # TODO: actual ID to be added
-        self.cfg_req_header.req_id = htotlp16(get_randbits(16))
+        # NOTE: Request ID for CfgRd and CfgWr is always 0
+        self.cfg_req_header.req_id = 0
         self.cfg_req_header.tag = get_randbits(8)
 
         # compute byte-enable bits
@@ -440,7 +454,11 @@ class CxlIoCfgReqPacket(CxlIoBasePacket):
         self.cfg_req_header.reg_num = (cfg_addr >> 2) & 0x3F
         return self
 
-    def get_cfg_addr_info(self):
+    def get_cfg_addr_read_info(self) -> int:
+        reg_num = (self.cfg_req_header.ext_reg_num << 6) | self.cfg_req_header.reg_num
+        return reg_num << 2, 4
+
+    def get_cfg_addr_write_info(self):
         reg_num = (self.cfg_req_header.ext_reg_num << 6) | self.cfg_req_header.reg_num
         be = self.cfg_req_header.first_dw_be
         b, pos = 1, 0
@@ -489,8 +507,7 @@ class CxlIoCfgRdPacket(CxlIoCfgReqPacket):
         )
         packet.system_header.payload_length = CxlIoCfgRdPacket.get_size()
 
-        # override for unit-testing
-        if req_id and tag:
+        if req_id != None and tag != None:
             packet.cfg_req_header.req_id = htotlp16(req_id)
             packet.cfg_req_header.tag = tag
         return packet
@@ -512,20 +529,27 @@ class CxlIoCfgWrPacket(CxlIoCfgReqPacket):
         req_id: int = None,
         tag: int = None,
     ) -> "CxlIoCfgWrPacket":
+        offset = cfg_addr % 4
         packet = CxlIoCfgWrPacket()
         packet.fill(id, cfg_addr, size)
         packet.cxl_io_header.fmt_type = (
             CXL_IO_FMT_TYPE.CFG_WR0 if is_type0 else CXL_IO_FMT_TYPE.CFG_WR1
         )
         packet = cast(CxlIoCfgWrPacket, packet)
-        packet.value = value
+        packet.value = value << (8 * offset)
         packet.system_header.payload_length = CxlIoCfgWrPacket.get_size()
 
-        # override for testing purposes
-        if req_id and tag:
+        if req_id != None and tag != None:
             packet.cfg_req_header.req_id = htotlp16(req_id)
             packet.cfg_req_header.tag = tag
         return packet
+
+    def get_value(self) -> int:
+        cfg_addr, size = self.get_cfg_addr_write_info()
+        offset = cfg_addr % 4
+        bit_offset = (offset % 4) * 8
+        bit_mask = (1 << size * 8) - 1
+        return (self.value >> bit_offset) & bit_mask
 
 
 class CXL_IO_CPL_STATUS(IntEnum):

--- a/opencxl/cxl/transport/transaction.py
+++ b/opencxl/cxl/transport/transaction.py
@@ -24,7 +24,6 @@ from opencxl.util.pci import (
 from opencxl.util.number import (
     get_randbits,
     htotlp16,
-    htotlp64,
     tlptoh16,
     extract_upper,
     extract_lower,
@@ -507,7 +506,7 @@ class CxlIoCfgRdPacket(CxlIoCfgReqPacket):
         )
         packet.system_header.payload_length = CxlIoCfgRdPacket.get_size()
 
-        if req_id != None and tag != None:
+        if req_id is not None and tag is not None:
             packet.cfg_req_header.req_id = htotlp16(req_id)
             packet.cfg_req_header.tag = tag
         return packet
@@ -539,7 +538,7 @@ class CxlIoCfgWrPacket(CxlIoCfgReqPacket):
         packet.value = value << (8 * offset)
         packet.system_header.payload_length = CxlIoCfgWrPacket.get_size()
 
-        if req_id != None and tag != None:
+        if req_id is not None and tag is not None:
             packet.cfg_req_header.req_id = htotlp16(req_id)
             packet.cfg_req_header.tag = tag
         return packet

--- a/opencxl/pci/component/config_space_manager.py
+++ b/opencxl/pci/component/config_space_manager.py
@@ -98,7 +98,7 @@ class ConfigSpaceManager(RunnableComponent):
             await self._send_unsupported_request(req_id, tag)
             return
 
-        cfg_addr, size = cfg_rd_packet.get_cfg_addr_info()
+        cfg_addr, size = cfg_rd_packet.get_cfg_addr_read_info()
 
         # TODO: Fix OOB
 
@@ -126,8 +126,8 @@ class ConfigSpaceManager(RunnableComponent):
             await self._send_unsupported_request(req_id, tag)
             return
 
-        cfg_addr, size = cfg_wr_packet.get_cfg_addr_info()
-        value = cfg_wr_packet.value
+        cfg_addr, size = cfg_wr_packet.get_cfg_addr_write_info()
+        value = cfg_wr_packet.get_value()
 
         # TODO: Fix OOB
 

--- a/opencxl/pci/component/mmio_manager.py
+++ b/opencxl/pci/component/mmio_manager.py
@@ -147,12 +147,8 @@ class MmioManager(PacketProcessor):
         await self._downstream_fifo.host_to_target.put(packet)
 
     async def _process_mmio_packet(self, mem_req_packet: CxlIoMemReqPacket):
-        addr_upper = mem_req_packet.mreq_header.addr_upper << 8
-        addr_lower = mem_req_packet.mreq_header.addr_lower << 2
-        address = tlptoh64(addr_upper | addr_lower)
-        size = (mem_req_packet.cxl_io_header.length_upper << 8) | (
-            mem_req_packet.cxl_io_header.length_lower & 0xFF
-        )
+        address = mem_req_packet.get_address()
+        size = mem_req_packet.get_data_size()
         req_id = tlptoh16(mem_req_packet.mreq_header.req_id)
         tag = mem_req_packet.mreq_header.tag
 

--- a/opencxl/pci/component/mmio_manager.py
+++ b/opencxl/pci/component/mmio_manager.py
@@ -11,7 +11,7 @@ from typing import Optional, List, Tuple, cast
 
 from opencxl.util.logger import logger
 from opencxl.util.unaligned_bit_structure import BitMaskedBitStructure
-from opencxl.util.number import round_up_to_power_of_2, tlptoh16, tlptoh64
+from opencxl.util.number import round_up_to_power_of_2, tlptoh16
 from opencxl.pci.component.fifo_pair import FifoPair
 from opencxl.pci.component.packet_processor import PacketProcessor
 


### PR DESCRIPTION
- Fixed parsing address from `CxlIoMemReqPacket`
- Fixed how the payload is used for both CfgRd and CfgWr
   - The data is always sent in one DW for CfgWr. Use byte enable to exclude bytes that will not need updates.
   - The data is already read in one DW for CfgRD. Host host should apply offset and masks for data received from CPLD packet 
- Added `config_read` and `config_write` to `RootPortDevice`
  -  Updated all helper functions to make them use `config_read` or `config_write` instead of sending packets to the cfg queue directly.
- Skip enumerating devices of non-zero function number if the device being enumerated is not a multi-function device.
- Fix handling config read/write requests from ConfigSpaceManager. 