### PR TITLE
cxl-util: Add skeleton support for starting complex host

### DIFF
--- a/opencxl/bin/cli.py
+++ b/opencxl/bin/cli.py
@@ -17,6 +17,7 @@ from opencxl.bin import cxl_switch
 from opencxl.bin import single_logical_device as sld
 from opencxl.bin import accelerator as accel
 from opencxl.bin import cxl_host
+from opencxl.bin import cxl_complex_host
 from opencxl.bin import mem
 
 
@@ -35,6 +36,7 @@ def validate_component(ctx, param, components):
         "sld-group",
         "t1accel-group",
         "t2accel-group",
+        "complex-host-group",
     ]
     if "all" in components:
         return ("fm", "switch", "host-group", "sld-group")
@@ -86,7 +88,7 @@ def start(
     """Start components"""
 
     # config file mandatory
-    config_components = ["switch", "sld-group", "host-group"]
+    config_components = ["switch", "sld-group", "host-group", "complex-host-group"]
     for c in comp:
         if c in config_components and not config_file:
             raise click.BadParameter(f"Must specify <config file> for {config_components}")
@@ -163,6 +165,11 @@ def start(
             threads.append(t_hgroup)
             t_hgroup.start()
 
+    if "complex-host-group" in comp:
+        t_chgroup = threading.Thread(target=start_complex_host_group, args=(ctx, config_file))
+        threads.append(t_chgroup)
+        t_chgroup.start()
+
 
 # helper functions
 def start_capture(ctx, pcap_file):
@@ -213,6 +220,10 @@ def start_switch(ctx, config_file):
 
 def start_host(ctx):
     ctx.invoke(cxl_host.start)
+
+
+def start_complex_host_group(ctx, config_file):
+    ctx.invoke(cxl_complex_host.start_group, config_file=config_file)
 
 
 def start_host_group(ctx, config_file, hm_mode):

--- a/opencxl/bin/cxl_complex_host.py
+++ b/opencxl/bin/cxl_complex_host.py
@@ -10,16 +10,9 @@ import click
 from opencxl.util.logger import logger
 from opencxl.cxl.environment import parse_cxl_environment
 from opencxl.cxl.component.cxl_component import PORT_TYPE
+from opencxl.cxl.component.root_complex.root_complex import RootComplexMemoryControllerConfig
+from opencxl.cxl.component.root_complex.root_port_client_manager import RootPortClientConfig
 from opencxl.apps.cxl_complex_host import CxlComplexHost, CxlComplexHostConfig
-
-
-# class CxlComplexHostConfig:
-#     host_name: str
-#     root_bus: int
-#     root_port_switch_type: ROOT_PORT_SWITCH_TYPE
-#     memory_controller: RootComplexMemoryControllerConfig
-#     root_ports: List[RootPortClientConfig] = field(default_factory=list)
-#     memory_ranges: List[MemoryRange] = field(default_factory=list)
 
 
 @click.group(name="host")
@@ -41,7 +34,24 @@ def start_group(config_file: str):
         return
 
     hosts = []
-    for idx, port_config in enumerate(environment.switch_config.port_configs):
+    for _, port_config in enumerate(environment.switch_config.port_configs):
         if port_config.type == PORT_TYPE.USP:
-            hosts.append(CxlComplexHost(port_index=idx))
+            # TODO: Placeholder config for test purpose,
+            # This doesn't even run. MUST be changed
+            host_name = "foo"
+            root_bus = 1
+            root_port_switch_type = 1
+            memory_controller = RootComplexMemoryControllerConfig(2000, "foo.bin")
+            root_ports = [RootPortClientConfig(0, "localhost", 8000)]
+            memory_ranges = [1, 2]
+
+            config = CxlComplexHostConfig(
+                host_name,
+                root_bus,
+                root_port_switch_type,
+                memory_controller,
+                root_ports,
+                memory_ranges,
+            )
+            hosts.append(CxlComplexHost(config))
     asyncio.run(run_host_group(hosts))

--- a/opencxl/bin/cxl_complex_host.py
+++ b/opencxl/bin/cxl_complex_host.py
@@ -1,0 +1,47 @@
+"""
+ Copyright (c) 2024, Eeum, Inc.
+
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+import asyncio
+import click
+from opencxl.util.logger import logger
+from opencxl.cxl.environment import parse_cxl_environment
+from opencxl.cxl.component.cxl_component import PORT_TYPE
+from opencxl.apps.cxl_complex_host import CxlComplexHost, CxlComplexHostConfig
+
+
+# class CxlComplexHostConfig:
+#     host_name: str
+#     root_bus: int
+#     root_port_switch_type: ROOT_PORT_SWITCH_TYPE
+#     memory_controller: RootComplexMemoryControllerConfig
+#     root_ports: List[RootPortClientConfig] = field(default_factory=list)
+#     memory_ranges: List[MemoryRange] = field(default_factory=list)
+
+
+@click.group(name="host")
+def host_group():
+    """Command group for managing CXL Complex Host"""
+    pass
+
+
+async def run_host_group(hosts):
+    tasks = [asyncio.create_task(host.run()) for host in hosts]
+    await asyncio.gather(*tasks)
+
+
+def start_group(config_file: str):
+    try:
+        environment = parse_cxl_environment(config_file)
+    except Exception as e:
+        logger.error(f"Failed to parse environment configuration: {e}")
+        return
+
+    hosts = []
+    for idx, port_config in enumerate(environment.switch_config.port_configs):
+        if port_config.type == PORT_TYPE.USP:
+            hosts.append(CxlComplexHost(port_index=idx))
+    asyncio.run(run_host_group(hosts))


### PR DESCRIPTION
Just adding the skeleton. This does not run successfully. Must be addressed by additional changes.