### PR TITLE
[Core:13] Add CXL.cache component registers necessary for routing

### DIFF
--- a/opencxl/cxl/device/root_port_device.py
+++ b/opencxl/cxl/device/root_port_device.py
@@ -96,6 +96,7 @@ class PciCapabilities:
 @dataclass
 class ComponentRegisters:
     hdm_decoder: int = 0
+    cache_id_route_table: int = 0
 
 
 @dataclass
@@ -638,6 +639,15 @@ class CxlRootPortDevice(RunnableComponent):
                 logger.info(
                     self._create_message(
                         f"HDM Decoder Capability Offset: 0x{hdm_decoder_offset:08x}"
+                    )
+                )
+            elif cxl_capability_id == 0x000D:
+                logger.info(self._create_message("Found Cache ID Route Table Capability Header"))
+                route_table_offset = cxl_cachemem_offset + offset
+                info.component_registers.cache_id_route_table = route_table_offset
+                logger.info(
+                    self._create_message(
+                        f"Cache ID Route Table Capability Offset: 0x{route_table_offset:08x}"
                     )
                 )
 

--- a/opencxl/cxl/mmio/component_register/memcache_register/cache_id_decoder_capabiility.py
+++ b/opencxl/cxl/mmio/component_register/memcache_register/cache_id_decoder_capabiility.py
@@ -1,0 +1,42 @@
+"""
+ Copyright (c) 2024, Eeum, Inc.
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+from opencxl.util.unaligned_bit_structure import (
+    BitMaskedBitStructure,
+    BitField,
+)
+
+
+class CxlCacheIdDecoderCapability(BitMaskedBitStructure):
+    _fields = [
+        BitField("explicit_cache_id_decoder_cmt_required", 0, 0),
+        BitField("rsvd", 1, 31),
+    ]
+
+
+class CxlCacheIdDecoderControl(BitMaskedBitStructure):
+    _fields = [
+        BitField("forward_cache_id", 0, 0),
+        BitField("assign_cache_id", 1, 1),
+        BitField("hdmd_t2_device_present", 2, 2),
+        BitField("cache_id_decoder_cmt", 3, 3),
+        BitField("rsvd", 4, 7),
+        BitField("hdmd_t2_device_cache_id", 8, 11),
+        BitField("rsvd2", 12, 15),
+        BitField("local_cache_id", 16, 19),
+        BitField("rsvd3", 20, 31),
+    ]
+
+
+class CxlCacheIdDecoderStatus(BitMaskedBitStructure):
+    _fields = [
+        BitField("cache_id_decoder_cmtd", 0, 0),
+        BitField("cache_id_decoder_err_not_cmtd", 1, 1),
+        BitField("rsvd", 2, 7),
+        BitField("cache_id_decoder_cmt_timeout_scale", 8, 11),
+        BitField("cache_id_decoder_cmt_timeout_base", 12, 15),
+        BitField("rsvd2", 16, 31),
+    ]

--- a/opencxl/cxl/mmio/component_register/memcache_register/cache_route_table.py
+++ b/opencxl/cxl/mmio/component_register/memcache_register/cache_route_table.py
@@ -1,0 +1,78 @@
+"""
+CXL Cache ID Route Table Capability Structure definitions.
+"""
+
+from enum import Enum
+from opencxl.util.unaligned_bit_structure import (
+    BitMaskedBitStructure,
+    BitField,
+    StructureField,
+    ByteField,
+    FIELD_ATTR,
+)
+
+
+# TODO: can probably optimize conversion to a single function/hashmap/list
+class CacheIdRTCommitTimeout(Enum):
+    _1_uS = 0b0000
+    _10_uS = 0b0001
+    _100_uS = 0b0010
+    _1_mS = 0b0011
+    _10_mS = 0b0100
+    _100_mS = 0b0101
+    _1_S = 0b0110
+    _10_S = 0b0111
+
+
+class CxlCacheIdRTCapability(BitMaskedBitStructure):
+    _fields = [
+        BitField("cache_id_target_count", 0, 4),
+        BitField("rsvd", 5, 7),
+        BitField("hdmd_type2_dev_max_count", 8, 11),
+        BitField("rsvd2", 12, 15),
+        BitField("explicit_cache_id_rt_cmt_req", 16, 16),
+        BitField("rsvd3", 17, 31),
+    ]
+
+
+class CxlCacheIdRTControl(BitMaskedBitStructure):
+    _fields = [BitField("cache_id_rt_cmt", 0, 0), BitField("rsvd", 1, 31)]
+
+
+class CxlCacheIdRTStatus(BitMaskedBitStructure):
+    _fields = [
+        BitField("cache_id_rt_cmtd", 0, 0),
+        BitField("cache_id_rt_err_not_cmtd", 1, 1),
+        BitField("rsvd", 2, 7),
+        BitField("cache_id_rt_cmt_timeout_scale", 8, 11),
+        BitField("cache_id_rt_cmt_timeout_base", 12, 15),
+        BitField("rsvd2", 16, 31),
+    ]
+
+
+class CxlCacheIdRTTargetN(BitMaskedBitStructure):
+    _fields = [BitField("valid", 0, 0), BitField("rsvd", 1, 7), BitField("port_number", 8, 15)]
+
+
+class CxlCacheIdRTCapabilityStructure2N(BitMaskedBitStructure):
+    _fields = [
+        StructureField("cxl_cache_id_rt_capability", 0x00, 0x03, CxlCacheIdRTCapability),
+        StructureField("cxl_cache_id_rt_control", 0x04, 0x07, CxlCacheIdRTControl),
+        StructureField("cxl_cache_id_rt_status", 0x08, 0x0B, CxlCacheIdRTStatus),
+        ByteField("rsvd", 0x0C, 0x0F, FIELD_ATTR.RESERVED),
+        StructureField("target_1", 0x10, 0x11, CxlCacheIdRTTargetN),
+        StructureField("target_2", 0x12, 0x13, CxlCacheIdRTTargetN),
+    ]
+
+
+class CxlCacheIdRTCapabilityStructure4N(BitMaskedBitStructure):
+    _fields = [
+        StructureField("cxl_cache_id_rt_capability", 0x00, 0x03, CxlCacheIdRTCapability),
+        StructureField("cxl_cache_id_rt_control", 0x04, 0x07, CxlCacheIdRTControl),
+        StructureField("cxl_cache_id_rt_status", 0x08, 0x0B, CxlCacheIdRTStatus),
+        ByteField("rsvd", 0x0C, 0x0F, FIELD_ATTR.RESERVED),
+        StructureField("target_1", 0x10, 0x11, CxlCacheIdRTTargetN),
+        StructureField("target_2", 0x12, 0x13, CxlCacheIdRTTargetN),
+        StructureField("target_3", 0x14, 0x15, CxlCacheIdRTTargetN),
+        StructureField("target_4", 0x16, 0x17, CxlCacheIdRTTargetN),
+    ]


### PR DESCRIPTION
For Cache ID route table capability structures, only N=2, N=4 are supported.