### PR TITLE
Home Agent code fix for Type3 device read/write w/ cache controller

### DIFF
--- a/opencxl/apps/cxl_complex_host.py
+++ b/opencxl/apps/cxl_complex_host.py
@@ -45,7 +45,7 @@ class CxlComplexHostConfig:
     memory_controller: RootComplexMemoryControllerConfig
     memory_ranges: List[MemoryRange] = field(default_factory=list)
     root_ports: List[RootPortClientConfig] = field(default_factory=list)
-    coh_type: Optional[COH_POLICY_TYPE] = COH_POLICY_TYPE.DotMemBI
+    coh_type: Optional[COH_POLICY_TYPE] = COH_POLICY_TYPE.NonCache
 
 
 class CxlComplexHost(RunnableComponent):
@@ -82,13 +82,14 @@ class CxlComplexHost(RunnableComponent):
             memory_controller=config.memory_controller,
             memory_ranges=config.memory_ranges,
             root_ports=root_complex_root_ports,
+            coh_type=config.coh_type,
         )
         self._root_complex = RootComplex(root_complex_config)
 
         if config.coh_type == COH_POLICY_TYPE.DotCache:
             cache_to_coh_agent_fifo = cache_to_coh_bridge_fifo
             coh_agent_to_cache_fifo = coh_bridge_to_cache_fifo
-        elif config.coh_type == COH_POLICY_TYPE.DotMemBI:
+        elif config.coh_type in (COH_POLICY_TYPE.NonCache, COH_POLICY_TYPE.DotMemBI):
             cache_to_coh_agent_fifo = cache_to_home_agent_fifo
             coh_agent_to_cache_fifo = home_agent_to_cache_fifo
 

--- a/opencxl/cxl/component/root_complex/root_complex.py
+++ b/opencxl/cxl/component/root_complex/root_complex.py
@@ -18,6 +18,7 @@ from opencxl.cxl.component.root_complex.root_port_switch import (
     RootPortSwitchConfig,
     RootPortSwitchPortConfig,
     ROOT_PORT_SWITCH_TYPE,
+    COH_POLICY_TYPE,
 )
 from opencxl.cxl.component.root_complex.home_agent import HomeAgent, HomeAgentConfig, MemoryRange
 from opencxl.cxl.component.root_complex.memory_controller import (
@@ -54,6 +55,7 @@ class RootComplexConfig:
     memory_controller: RootComplexMemoryControllerConfig
     memory_ranges: List[MemoryRange] = field(default_factory=list)
     root_ports: List[RootPortSwitchPortConfig] = field(default_factory=list)
+    coh_type: Optional[COH_POLICY_TYPE] = COH_POLICY_TYPE.NonCache
 
 
 class RootComplex(RunnableComponent):
@@ -114,6 +116,7 @@ class RootComplex(RunnableComponent):
             upstream_cache_to_home_agent_fifo=cache_to_home_agent_fifo,
             upstream_home_agent_to_cache_fifo=home_agent_to_cache_fifo,
             downstream_cxl_mem_fifos=root_port_switch_upstream_connection.cxl_mem_fifo,
+            coh_type=config.coh_type,
         )
         self._home_agent = HomeAgent(home_agent_config)
 

--- a/opencxl/cxl/component/root_complex/root_port_switch.py
+++ b/opencxl/cxl/component/root_complex/root_port_switch.py
@@ -16,6 +16,7 @@ from opencxl.pci.component.packet_processor import PacketProcessor
 
 
 class COH_POLICY_TYPE(Enum):
+    NonCache = auto()
     DotCache = auto()
     DotMemBI = auto()
 


### PR DESCRIPTION
Type3 read/write code runs with cache controller module.
Added coh type for Type3

To do) The host needs to make address range list after enumeration of devices and switches.
The host issues read/write requests packets and handles completions for cache coherency with the range list.