### PR TITLE
perf: Optimize UnalignedBitStructure write_bytes and read_bytes

### DIFF
--- a/opencxl/util/unaligned_bit_structure.py
+++ b/opencxl/util/unaligned_bit_structure.py
@@ -216,17 +216,17 @@ class ShareableByteArray:
 
     def write_bytes(self, start_offset: int, end_offset: int, value: int):
         # NOTE: Assume little-endian byte order
-        for offset in range(start_offset, end_offset + 1):
-            self[offset] = value & 0xFF
-            value = value >> BITS_IN_BYTE
+        length = end_offset - start_offset + 1
+        start = start_offset + self.offset
+        end = end_offset + self.offset
+        val_bytes = value.to_bytes(length, "little")
+        self._data[start : end + 1] = val_bytes
 
     def read_bytes(self, start_offset: int, end_offset: int) -> int:
         # NOTE: Assume little-endian byte order
-        value = 0
-        for offset in range(end_offset, start_offset - 1, -1):
-            value = value << BITS_IN_BYTE
-            value = value | self[offset]
-        return value
+        start = start_offset + self.offset
+        end = end_offset + self.offset
+        return int.from_bytes(self._data[start : end + 1], "little")
 
     def write_bits(self, offset, width, value):
         """

--- a/tests/test_pci_component_mmio_manager.py
+++ b/tests/test_pci_component_mmio_manager.py
@@ -113,6 +113,11 @@ async def test_mmio_manager_write():
     # bar_entry.register.write_bytes.assert_called_with(0, size - 1, value)
 
 
+class BytesLikeMock(MagicMock):
+    def to_bytes(self, *args, **kwargs):
+        return int(self).to_bytes(*args, **kwargs)
+
+
 @pytest.mark.asyncio
 async def test_mmio_manager_read():
     # pylint: disable=protected-access
@@ -143,7 +148,7 @@ async def test_mmio_manager_read():
 
     # Test when address is out of bound
     bar_entry.base_address = 0x1000
-    bar_entry.register = MagicMock()
+    bar_entry.register = BytesLikeMock()
     bar_entry.register.__len__.return_value = 0x10
     packet = CxlIoMemRdPacket.create(addr=0x1000 - 1, length=4)
     await upstream_fifo.host_to_target.put(packet)
@@ -155,7 +160,7 @@ async def test_mmio_manager_read():
 
     # Test when address is valid
     bar_entry.base_address = 0x1000
-    bar_entry.register = MagicMock()
+    bar_entry.register = BytesLikeMock()
     bar_entry.register.__len__.return_value = 0x10
     packet = CxlIoMemRdPacket.create(addr=0x1000, length=4)
     await upstream_fifo.host_to_target.put(packet)


### PR DESCRIPTION
Results from profiling using pytest case `tests/test_cxl_image_classification_host.py::test_cxl_host_type1_complex_host_ete`.

Before:
```
   ncalls  tottime  cumtime  filename:lineno(function)
     7799    1.890    1.966    /home/kyeyoon/eeum-dev/my-opencxl-core/opencxl/util/unaligned_bit_structure.py:217(write_bytes)
```
vs.

After:
```
   ncalls  tottime  cumtime  filename:lineno(function)
     7799    0.010    0.012    /home/kyeyoon/eeum-dev/my-opencxl-core/opencxl/util/unaligned_bit_structure.py:217(write_bytes)
```