### PR TITLE
Initial MLD prototype (#53, #55, #51, #58, #59)

### DIFF
--- a/opencxl/apps/multi_logical_device.py
+++ b/opencxl/apps/multi_logical_device.py
@@ -1,0 +1,80 @@
+"""
+ Copyright (c) 2024, Eeum, Inc.
+
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+from asyncio import gather, create_task
+from typing import List
+
+from opencxl.util.component import RunnableComponent
+from opencxl.cxl.device.cxl_type3_device import CxlType3Device, CXL_T3_DEV_TYPE
+from opencxl.cxl.component.switch_connection_client import SwitchConnectionClient
+from opencxl.cxl.component.cxl_component import CXL_COMPONENT_TYPE
+from opencxl.cxl.component.cxl_packet_processor import FifoGroup
+
+
+class MultiLogicalDevice(RunnableComponent):
+    def __init__(
+        self,
+        num_ld,
+        port_index: int,
+        memory_sizes: List[int],
+        memory_files: List[str],
+        host: str = "0.0.0.0",
+        port: int = 8000,
+    ):
+        label = f"Port{port_index}"
+        super().__init__(label)
+
+        self._cxl_type3_devices = []
+
+        self._sw_conn_client = SwitchConnectionClient(
+            port_index, CXL_COMPONENT_TYPE.LD, num_ld=num_ld, host=host, port=port
+        )
+        base_outgoing = FifoGroup(
+            self._sw_conn_client.get_cxl_connection()[0].cfg_fifo.target_to_host,
+            self._sw_conn_client.get_cxl_connection()[0].mmio_fifo.target_to_host,
+            self._sw_conn_client.get_cxl_connection()[0].cxl_mem_fifo.target_to_host,
+            self._sw_conn_client.get_cxl_connection()[0].cxl_cache_fifo.target_to_host,
+        )
+
+        # Share the outgoing queue across multiple LDs
+        # TODO: avoid creation at all
+        if num_ld > 1:
+            for i in range(1, num_ld):
+                connection = self._sw_conn_client.get_cxl_connection()[i]
+                base_cfg = base_outgoing
+                connection.cfg_fifo.target_to_host = base_cfg.cfg_space
+                connection.mmio_fifo.target_to_host = base_cfg.mmio
+                connection.cxl_mem_fifo.target_to_host = base_cfg.cxl_mem
+                connection.cxl_cache_fifo.target_to_host = base_cfg.cxl_cache
+
+        for ld in range(num_ld):
+            cxl_type3_device = CxlType3Device(
+                transport_connection=self._sw_conn_client.get_cxl_connection()[ld],
+                memory_size=memory_sizes[ld],
+                memory_file=memory_files[ld],
+                dev_type=CXL_T3_DEV_TYPE.MLD,
+                label=label,
+                ld_id=ld,
+            )
+            self._cxl_type3_devices.append(cxl_type3_device)
+
+    async def _run(self):
+        sw_conn_client_task = [create_task(self._sw_conn_client.run())]
+        cxl_type3_device_tasks = [create_task(device.run()) for device in self._cxl_type3_devices]
+
+        tasks = sw_conn_client_task + cxl_type3_device_tasks
+
+        await self._change_status_to_running()
+        await gather(*tasks)
+
+    async def _stop(self):
+        sw_conn_client_task = [create_task(self._sw_conn_client.stop())]
+        cxl_type3_device_tasks = [create_task(device.stop()) for device in self._cxl_type3_devices]
+
+        tasks = sw_conn_client_task + cxl_type3_device_tasks
+
+        await gather(*tasks)

--- a/opencxl/apps/multi_logical_device.py
+++ b/opencxl/apps/multi_logical_device.py
@@ -72,7 +72,6 @@ class MultiLogicalDevice(RunnableComponent):
                 memory_file=memory_files[ld],
                 dev_type=CXL_T3_DEV_TYPE.MLD,
                 label=label,
-                ld_id=ld,
             )
             self._cxl_type3_devices.append(cxl_type3_device)
 

--- a/opencxl/apps/multi_logical_device.py
+++ b/opencxl/apps/multi_logical_device.py
@@ -24,36 +24,50 @@ class MultiLogicalDevice(RunnableComponent):
         memory_files: List[str],
         host: str = "0.0.0.0",
         port: int = 8000,
+        test_mode: bool = False,
+        cxl_connections=None,
     ):
         label = f"Port{port_index}"
         super().__init__(label)
 
         self._cxl_type3_devices = []
+        self._test_mode = test_mode
 
-        self._sw_conn_client = SwitchConnectionClient(
-            port_index, CXL_COMPONENT_TYPE.LD, num_ld=num_ld, host=host, port=port
-        )
+        assert (
+            not test_mode or cxl_connections is not None
+        ), "get_cxl_connection must be passed in test mode"
+        assert (
+            test_mode or cxl_connections is None
+        ), "get_cxl_connection must not be passed in non-test mode"
+
+        if cxl_connections is not None:
+            self._get_cxl_connection = cxl_connections
+        else:
+            self._sw_conn_client = SwitchConnectionClient(
+                port_index, CXL_COMPONENT_TYPE.LD, num_ld=num_ld, host=host, port=port
+            )
+            self._get_cxl_connection = self._sw_conn_client.get_cxl_connection()
+
         base_outgoing = FifoGroup(
-            self._sw_conn_client.get_cxl_connection()[0].cfg_fifo.target_to_host,
-            self._sw_conn_client.get_cxl_connection()[0].mmio_fifo.target_to_host,
-            self._sw_conn_client.get_cxl_connection()[0].cxl_mem_fifo.target_to_host,
-            self._sw_conn_client.get_cxl_connection()[0].cxl_cache_fifo.target_to_host,
+            self._get_cxl_connection[0].cfg_fifo.target_to_host,
+            self._get_cxl_connection[0].mmio_fifo.target_to_host,
+            self._get_cxl_connection[0].cxl_mem_fifo.target_to_host,
+            self._get_cxl_connection[0].cxl_cache_fifo.target_to_host,
         )
 
         # Share the outgoing queue across multiple LDs
         # TODO: avoid creation at all
         if num_ld > 1:
             for i in range(1, num_ld):
-                connection = self._sw_conn_client.get_cxl_connection()[i]
-                base_cfg = base_outgoing
-                connection.cfg_fifo.target_to_host = base_cfg.cfg_space
-                connection.mmio_fifo.target_to_host = base_cfg.mmio
-                connection.cxl_mem_fifo.target_to_host = base_cfg.cxl_mem
-                connection.cxl_cache_fifo.target_to_host = base_cfg.cxl_cache
+                connection = self._get_cxl_connection[i]
+                connection.cfg_fifo.target_to_host = base_outgoing.cfg_space
+                connection.mmio_fifo.target_to_host = base_outgoing.mmio
+                connection.cxl_mem_fifo.target_to_host = base_outgoing.cxl_mem
+                connection.cxl_cache_fifo.target_to_host = base_outgoing.cxl_cache
 
         for ld in range(num_ld):
             cxl_type3_device = CxlType3Device(
-                transport_connection=self._sw_conn_client.get_cxl_connection()[ld],
+                transport_connection=self._get_cxl_connection[ld],
                 memory_size=memory_sizes[ld],
                 memory_file=memory_files[ld],
                 dev_type=CXL_T3_DEV_TYPE.MLD,
@@ -63,18 +77,19 @@ class MultiLogicalDevice(RunnableComponent):
             self._cxl_type3_devices.append(cxl_type3_device)
 
     async def _run(self):
-        sw_conn_client_task = [create_task(self._sw_conn_client.run())]
-        cxl_type3_device_tasks = [create_task(device.run()) for device in self._cxl_type3_devices]
+        run_tasks = [create_task(device.run()) for device in self._cxl_type3_devices]
+        wait_tasks = [create_task(device.wait_for_ready()) for device in self._cxl_type3_devices]
+        if not self._test_mode:
+            run_tasks += [create_task(self._sw_conn_client.run())]
+            wait_tasks += [create_task(self._sw_conn_client.wait_for_ready())]
 
-        tasks = sw_conn_client_task + cxl_type3_device_tasks
-
+        await gather(*wait_tasks)
         await self._change_status_to_running()
-        await gather(*tasks)
+        await gather(*run_tasks)
 
     async def _stop(self):
-        sw_conn_client_task = [create_task(self._sw_conn_client.stop())]
-        cxl_type3_device_tasks = [create_task(device.stop()) for device in self._cxl_type3_devices]
+        stop_tasks = [create_task(device.stop()) for device in self._cxl_type3_devices]
+        if not self._test_mode:
+            stop_tasks += [create_task(self._sw_conn_client.stop())]
 
-        tasks = sw_conn_client_task + cxl_type3_device_tasks
-
-        await gather(*tasks)
+        await gather(*stop_tasks)

--- a/opencxl/apps/single_logical_device.py
+++ b/opencxl/apps/single_logical_device.py
@@ -37,12 +37,17 @@ class SingleLogicalDevice(RunnableComponent):
         )
 
     async def _run(self):
-        tasks = [
+        run_tasks = [
             create_task(self._sw_conn_client.run()),
             create_task(self._cxl_type3_device.run()),
         ]
+        wait_tasks = [
+            create_task(self._sw_conn_client.wait_for_ready()),
+            create_task(self._cxl_type3_device.wait_for_ready()),
+        ]
+        await gather(*wait_tasks)
         await self._change_status_to_running()
-        await gather(*tasks)
+        await gather(*run_tasks)
 
     async def _stop(self):
         tasks = [

--- a/opencxl/cxl/component/cxl_io_manager.py
+++ b/opencxl/cxl/component/cxl_io_manager.py
@@ -24,12 +24,14 @@ class CxlIoManager(RunnableComponent):
         device_type: PCI_DEVICE_TYPE,
         init_callback: Callable[[MmioManager, ConfigSpaceManager], None],
         label: Optional[str] = None,
+        ld_id: Optional[int] = None,
     ):
         super().__init__(label)
         self._mmio_manager = MmioManager(
             mmio_upstream_fifo,
             mmio_downstream_fifo,
             label=label,
+            ld_id=ld_id,
         )
         self._config_space_manager = ConfigSpaceManager(
             cfg_upstream_fifo,

--- a/opencxl/cxl/component/cxl_io_manager.py
+++ b/opencxl/cxl/component/cxl_io_manager.py
@@ -24,14 +24,12 @@ class CxlIoManager(RunnableComponent):
         device_type: PCI_DEVICE_TYPE,
         init_callback: Callable[[MmioManager, ConfigSpaceManager], None],
         label: Optional[str] = None,
-        ld_id: Optional[int] = None,
     ):
         super().__init__(label)
         self._mmio_manager = MmioManager(
             mmio_upstream_fifo,
             mmio_downstream_fifo,
             label=label,
-            ld_id=ld_id,
         )
         self._config_space_manager = ConfigSpaceManager(
             cfg_upstream_fifo,

--- a/opencxl/cxl/component/cxl_mem_manager.py
+++ b/opencxl/cxl/component/cxl_mem_manager.py
@@ -53,8 +53,9 @@ class CxlMemManager(PacketProcessor):
 
         address = mem_rd_packet.get_address()
         data = await self._memory_device_component.read_mem(address)
+        ld_id = mem_rd_packet.m2sreq_header.ld_id
 
-        packet = CxlMemMemDataPacket.create(data)
+        packet = CxlMemMemDataPacket.create(data, ld_id=ld_id)
         await self._upstream_fifo.target_to_host.put(packet)
 
     async def _process_cxl_mem_wr_packet(self, mem_wr_packet: CxlMemMemWrPacket):
@@ -68,9 +69,10 @@ class CxlMemManager(PacketProcessor):
 
         address = mem_wr_packet.get_address()
         data = mem_wr_packet.data
+        ld_id = mem_wr_packet.m2srwd_header.ld_id
         await self._memory_device_component.write_mem(address, data)
 
-        packet = CxlMemCmpPacket.create()
+        packet = CxlMemCmpPacket.create(ld_id=ld_id)
         await self._upstream_fifo.target_to_host.put(packet)
 
     async def process_cxl_mem_bisnp_packet(self, mem_bisnp_packet: CxlMemBISnpPacket):

--- a/opencxl/cxl/component/switch_connection_client.py
+++ b/opencxl/cxl/component/switch_connection_client.py
@@ -34,6 +34,7 @@ class SwitchConnectionClient(RunnableComponent):
         self,
         port_index: int,
         component_type: CXL_COMPONENT_TYPE,
+        num_ld: int = 0,
         host: str = "0.0.0.0",
         port: int = 8000,
         retry: bool = True,
@@ -45,7 +46,10 @@ class SwitchConnectionClient(RunnableComponent):
         self._port = port
         self._port_index = port_index
         self._component_type = component_type
-        self._cxl_connection = CxlConnection()
+        if num_ld != 0:
+            self._cxl_connection = [CxlConnection() for _ in range(num_ld)]
+        else:
+            self._cxl_connection = CxlConnection()
         self._packet_processor = None
         self._injected_error = None
         self._retry = retry

--- a/opencxl/cxl/device/cxl_type3_device.py
+++ b/opencxl/cxl/device/cxl_type3_device.py
@@ -44,6 +44,7 @@ from opencxl.pci.component.pci import (
     PciComponentIdentity,
     EEUM_VID,
     SW_SLD_DID,
+    SW_MLD_DID,
     PCI_CLASS,
     MEMORY_CONTROLLER_SUBCLASS,
 )
@@ -68,6 +69,7 @@ class CxlType3Device(RunnableComponent):
         dev_type: CXL_T3_DEV_TYPE,
         decoder_count: HDM_DECODER_COUNT = HDM_DECODER_COUNT.DECODER_4,
         label: Optional[str] = None,
+        ld_id: Optional[int] = None,
     ):
         # pylint: disable=unused-argument
         super().__init__(label)
@@ -76,6 +78,7 @@ class CxlType3Device(RunnableComponent):
         self._decoder_count = decoder_count
         self._cxl_memory_device_component = None
         self._upstream_connection = transport_connection
+        self._ld_id = ld_id
 
         self._cxl_io_manager = CxlIoManager(
             self._upstream_connection.mmio_fifo,
@@ -85,6 +88,7 @@ class CxlType3Device(RunnableComponent):
             device_type=PCI_DEVICE_TYPE.ENDPOINT,
             init_callback=self._init_device,
             label=self._label,
+            ld_id=self._ld_id,
         )
         self._cxl_mem_manager = CxlMemManager(
             upstream_fifo=self._upstream_connection.cxl_mem_fifo,
@@ -102,7 +106,7 @@ class CxlType3Device(RunnableComponent):
         # Create PCiComponent
         pci_identity = PciComponentIdentity(
             vendor_id=EEUM_VID,
-            device_id=SW_SLD_DID,
+            device_id=SW_SLD_DID if self._ld_id is None else SW_MLD_DID,
             base_class_code=PCI_CLASS.MEMORY_CONTROLLER,
             sub_class_coce=MEMORY_CONTROLLER_SUBCLASS.CXL_MEMORY_DEVICE,
             programming_interface=0x10,

--- a/opencxl/cxl/device/cxl_type3_device.py
+++ b/opencxl/cxl/device/cxl_type3_device.py
@@ -69,16 +69,15 @@ class CxlType3Device(RunnableComponent):
         dev_type: CXL_T3_DEV_TYPE,
         decoder_count: HDM_DECODER_COUNT = HDM_DECODER_COUNT.DECODER_4,
         label: Optional[str] = None,
-        ld_id: Optional[int] = None,
     ):
         # pylint: disable=unused-argument
         super().__init__(label)
         self._memory_size = memory_size
         self._memory_file = memory_file
+        self._dev_type = dev_type
         self._decoder_count = decoder_count
         self._cxl_memory_device_component = None
         self._upstream_connection = transport_connection
-        self._ld_id = ld_id
 
         self._cxl_io_manager = CxlIoManager(
             self._upstream_connection.mmio_fifo,
@@ -88,7 +87,6 @@ class CxlType3Device(RunnableComponent):
             device_type=PCI_DEVICE_TYPE.ENDPOINT,
             init_callback=self._init_device,
             label=self._label,
-            ld_id=self._ld_id,
         )
         self._cxl_mem_manager = CxlMemManager(
             upstream_fifo=self._upstream_connection.cxl_mem_fifo,
@@ -106,7 +104,7 @@ class CxlType3Device(RunnableComponent):
         # Create PCiComponent
         pci_identity = PciComponentIdentity(
             vendor_id=EEUM_VID,
-            device_id=SW_SLD_DID if self._ld_id is None else SW_MLD_DID,
+            device_id=SW_SLD_DID if self._dev_type is CXL_T3_DEV_TYPE.SLD else SW_MLD_DID,
             base_class_code=PCI_CLASS.MEMORY_CONTROLLER,
             sub_class_coce=MEMORY_CONTROLLER_SUBCLASS.CXL_MEMORY_DEVICE,
             programming_interface=0x10,

--- a/opencxl/cxl/device/port_device.py
+++ b/opencxl/cxl/device/port_device.py
@@ -100,6 +100,7 @@ class CxlPortDevice(RunnableComponent):
             create_task(self._cxl_mem_manager.wait_for_ready()),
             create_task(self._cxl_cache_manager.wait_for_ready()),
         ]
+        # pylint: disable=duplicate-code
         await gather(*wait_tasks)
         await self._change_status_to_running()
         await gather(*run_tasks)

--- a/opencxl/cxl/transport/transaction.py
+++ b/opencxl/cxl/transport/transaction.py
@@ -375,7 +375,12 @@ class CxlIoMemReqPacket(CxlIoBasePacket):
 class CxlIoMemRdPacket(CxlIoMemReqPacket):
     @classmethod
     def create(
-        cls, addr: int, length: int, req_id: Optional[int] = None, tag: Optional[int] = None
+        cls,
+        addr: int,
+        length: int,
+        req_id: Optional[int] = None,
+        tag: Optional[int] = None,
+        ld_id: int = 0,
     ) -> "CxlIoMemRdPacket":
         if req_id is not None:
             req_id = htotlp16(req_id)
@@ -388,6 +393,7 @@ class CxlIoMemRdPacket(CxlIoMemReqPacket):
         packet = CxlIoMemRdPacket()
         packet.fill(addr, length, req_id, tag)
         packet.cxl_io_header.fmt_type = CXL_IO_FMT_TYPE.MRD_64B
+        packet.tlp_prefix.ld_id = ld_id
         packet.system_header.payload_length = CxlIoMemRdPacket.get_size()
         return packet
 
@@ -407,6 +413,7 @@ class CxlIoMemWrPacket(CxlIoMemReqPacket):
         data: int,
         req_id: Optional[int] = None,
         tag: Optional[int] = None,
+        ld_id: int = 0,
     ) -> "CxlIoMemWrPacket":
         if req_id is not None:
             req_id = htotlp16(req_id)
@@ -419,6 +426,7 @@ class CxlIoMemWrPacket(CxlIoMemReqPacket):
         packet = CxlIoMemWrPacket()
         packet.fill(addr, length, req_id, tag)
         packet.cxl_io_header.fmt_type = CXL_IO_FMT_TYPE.MWR_64B
+        packet.tlp_prefix.ld_id = ld_id
         packet.set_dynamic_field_length(length)
         packet.data = data
         packet.system_header.payload_length = len(packet)
@@ -543,6 +551,7 @@ class CxlIoCfgRdPacket(CxlIoCfgReqPacket):
         is_type0: bool = True,
         req_id: Optional[int] = None,
         tag: Optional[int] = None,
+        ld_id: int = 0,
     ) -> "CxlIoCfgRdPacket":
         if req_id is not None:
             req_id = htotlp16(req_id)
@@ -558,6 +567,7 @@ class CxlIoCfgRdPacket(CxlIoCfgReqPacket):
             CXL_IO_FMT_TYPE.CFG_RD0 if is_type0 else CXL_IO_FMT_TYPE.CFG_RD1
         )
         packet.system_header.payload_length = CxlIoCfgRdPacket.get_size()
+        packet.tlp_prefix.ld_id = ld_id
         return packet
 
 
@@ -577,6 +587,7 @@ class CxlIoCfgWrPacket(CxlIoCfgReqPacket):
         is_type0: bool = True,
         req_id: Optional[int] = None,
         tag: Optional[int] = None,
+        ld_id: int = 0,
     ) -> "CxlIoCfgWrPacket":
         if req_id is not None:
             req_id = htotlp16(req_id)
@@ -592,6 +603,7 @@ class CxlIoCfgWrPacket(CxlIoCfgReqPacket):
         packet.cxl_io_header.fmt_type = (
             CXL_IO_FMT_TYPE.CFG_WR0 if is_type0 else CXL_IO_FMT_TYPE.CFG_WR1
         )
+        packet.tlp_prefix.ld_id = ld_id
         packet = cast(CxlIoCfgWrPacket, packet)
         packet.value = value << (8 * offset)
         packet.system_header.payload_length = CxlIoCfgWrPacket.get_size()
@@ -656,7 +668,7 @@ class CxlIoCompletionPacket(CxlIoBasePacket):
 
     @staticmethod
     def create(
-        req_id: int, tag: int, status: CXL_IO_CPL_STATUS = CXL_IO_CPL_STATUS.SC
+        req_id: int, tag: int, status: CXL_IO_CPL_STATUS = CXL_IO_CPL_STATUS.SC, ld_id: int = 0
     ) -> "CxlIoCompletionPacket":
         packet = CxlIoCompletionPacket()
         packet.system_header.payload_type = PAYLOAD_TYPE.CXL_IO
@@ -664,6 +676,7 @@ class CxlIoCompletionPacket(CxlIoBasePacket):
         packet.cxl_io_header.fmt_type = CXL_IO_FMT_TYPE.CPL
         packet.cxl_io_header.length_upper = 0b000
         packet.cxl_io_header.length_lower = 0b00000000
+        packet.tlp_prefix.ld_id = ld_id
         # TODO: actual ID to be added
         packet.cpl_header.cpl_id = htotlp16(get_randbits(16))
         packet.cpl_header.status = status
@@ -700,6 +713,7 @@ class CxlIoCompletionWithDataPacket(CxlIoBasePacket):
         data: int,
         status: CXL_IO_CPL_STATUS = CXL_IO_CPL_STATUS.SC,
         pload_len=0x04,
+        ld_id: int = 0,
     ) -> "CxlIoCompletionWithDataPacket":
         # for config reads, always 1 DWORD (4 bytes)
 
@@ -722,6 +736,8 @@ class CxlIoCompletionWithDataPacket(CxlIoBasePacket):
 
         packet.set_dynamic_field_length(pload_len)
         packet.data = data
+
+        packet.tlp_prefix.ld_id = ld_id
 
         packet.system_header.payload_length = len(packet)
 
@@ -1642,6 +1658,7 @@ class CxlMemMemRdPacket(CxlMemM2SReqPacket):
         meta_field: Optional[CXL_MEM_META_FIELD] = CXL_MEM_META_FIELD.NO_OP,
         meta_value: Optional[CXL_MEM_META_VALUE] = CXL_MEM_META_VALUE.ANY,
         snp_type: Optional[CXL_MEM_M2S_SNP_TYPE] = CXL_MEM_M2S_SNP_TYPE.NO_OP,
+        ld_id: int = 0,
     ) -> "CxlMemMemRdPacket":
         packet = CxlMemMemRdPacket()
         packet.system_header.payload_type = PAYLOAD_TYPE.CXL_MEM
@@ -1652,6 +1669,7 @@ class CxlMemMemRdPacket(CxlMemM2SReqPacket):
         packet.m2sreq_header.meta_field = meta_field
         packet.m2sreq_header.meta_value = meta_value
         packet.m2sreq_header.snp_type = snp_type
+        packet.m2sreq_header.ld_id = ld_id
         if addr % 0x40:
             raise Exception("Address must be a multiple of 0x40")
         packet.m2sreq_header.addr = addr >> 6
@@ -1667,6 +1685,7 @@ class CxlMemMemWrPacket(CxlMemM2SRwDPacket):
         meta_field: Optional[CXL_MEM_META_FIELD] = CXL_MEM_META_FIELD.NO_OP,
         meta_value: Optional[CXL_MEM_META_VALUE] = CXL_MEM_META_VALUE.ANY,
         snp_type: Optional[CXL_MEM_M2S_SNP_TYPE] = CXL_MEM_M2S_SNP_TYPE.NO_OP,
+        ld_id: int = 0,
     ) -> "CxlMemMemWrPacket":
         packet = CxlMemMemWrPacket()
         packet.system_header.payload_type = PAYLOAD_TYPE.CXL_MEM
@@ -1677,6 +1696,7 @@ class CxlMemMemWrPacket(CxlMemM2SRwDPacket):
         packet.m2srwd_header.meta_field = meta_field
         packet.m2srwd_header.meta_value = meta_value
         packet.m2srwd_header.snp_type = snp_type
+        packet.m2srwd_header.ld_id = ld_id
         if addr % 0x40:
             raise Exception("Address must be a multiple of 0x40")
         packet.m2srwd_header.addr = addr >> 6
@@ -1737,6 +1757,7 @@ class CxlMemMemDataPacket(CxlMemS2MDRSPacket):
         drs_opcode: Optional[CXL_MEM_S2MDRS_OPCODE] = CXL_MEM_S2MDRS_OPCODE.MEM_DATA,
         meta_field: Optional[CXL_MEM_META_FIELD] = CXL_MEM_META_FIELD.NO_OP,
         meta_value: Optional[CXL_MEM_META_VALUE] = CXL_MEM_META_VALUE.ANY,
+        ld_id: int = 0,
     ) -> "CxlMemMemDataPacket":
         packet = CxlMemMemDataPacket()
         packet.system_header.payload_type = PAYLOAD_TYPE.CXL_MEM
@@ -1745,6 +1766,7 @@ class CxlMemMemDataPacket(CxlMemS2MDRSPacket):
         packet.s2mdrs_header.opcode = drs_opcode
         packet.s2mdrs_header.meta_field = meta_field
         packet.s2mdrs_header.meta_value = meta_value
+        packet.s2mdrs_header.ld_id = ld_id
         packet.data = data
         return packet
 
@@ -1755,6 +1777,7 @@ class CxlMemCmpPacket(CxlMemS2MNDRPacket):
         ndr_opcode: Optional[CXL_MEM_S2MNDR_OPCODE] = CXL_MEM_S2MNDR_OPCODE.CMP,
         meta_field: Optional[CXL_MEM_META_FIELD] = CXL_MEM_META_FIELD.NO_OP,
         meta_value: Optional[CXL_MEM_META_VALUE] = CXL_MEM_META_VALUE.ANY,
+        ld_id: int = 0,
     ) -> "CxlMemCmpPacket":
         packet = CxlMemCmpPacket()
         packet.system_header.payload_type = PAYLOAD_TYPE.CXL_MEM
@@ -1764,6 +1787,7 @@ class CxlMemCmpPacket(CxlMemS2MNDRPacket):
         packet.s2mndr_header.opcode = ndr_opcode
         packet.s2mndr_header.meta_field = meta_field
         packet.s2mndr_header.meta_value = meta_value
+        packet.s2mndr_header.ld_id = ld_id
         return packet
 
 

--- a/opencxl/pci/component/mmio_manager.py
+++ b/opencxl/pci/component/mmio_manager.py
@@ -50,6 +50,7 @@ class MmioManager(PacketProcessor):
         upstream_fifo: FifoPair,
         downstream_fifo: Optional[FifoPair] = None,
         label: Optional[str] = None,
+        ld_id: Optional[int] = None,
     ):
         self._downstream_fifo: Optional[FifoPair]
         self._upstream_fifo: FifoPair
@@ -60,6 +61,7 @@ class MmioManager(PacketProcessor):
         self._prefetchable_memory_base = 0
         self._prefetchable_memory_limit = 0
         self._bar_entries: List[BarEntry] = []
+        self._ld_id = ld_id
 
     # NOTE: Setting memory ranges is only used for bridge devices
 
@@ -140,6 +142,11 @@ class MmioManager(PacketProcessor):
             packet = CxlIoCompletionWithDataPacket.create(req_id, tag, data, pload_len=data_len)
         else:
             packet = CxlIoCompletionPacket.create(req_id, tag)
+        # Add MLD
+        if self._ld_id is not None:
+            packet.tlp_prefix.ld_id = self._ld_id
+        else:
+            packet.tlp_prefix.ld_id = 0
         await self._upstream_fifo.target_to_host.put(packet)
 
     async def _forward_request(self, packet: CxlIoBasePacket):

--- a/tests/test_cxl_device_multi_logical_device.py
+++ b/tests/test_cxl_device_multi_logical_device.py
@@ -1,0 +1,387 @@
+"""
+ Copyright (c) 2024, Eeum, Inc.
+
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+from asyncio import create_task
+import asyncio
+import struct
+from typing import cast
+import pytest
+
+from opencxl.apps.multi_logical_device import MultiLogicalDevice
+from opencxl.cxl.component.common import CXL_COMPONENT_TYPE
+from opencxl.cxl.component.cxl_packet_processor import CxlPacketProcessor
+from opencxl.cxl.component.packet_reader import PacketReader
+from opencxl.cxl.component.cxl_connection import CxlConnection
+from opencxl.pci.component.pci import EEUM_VID, SW_MLD_DID
+from opencxl.util.number_const import MB
+from opencxl.util.logger import logger
+from opencxl.util.pci import create_bdf
+from opencxl.cxl.transport.transaction import (
+    CxlIoCfgRdPacket,
+    CxlIoMemRdPacket,
+    CxlIoMemWrPacket,
+    CxlIoCfgWrPacket,
+    CxlMemMemRdPacket,
+    CxlMemMemWrPacket,
+    CxlIoCompletionWithDataPacket,
+    is_cxl_io_completion_status_sc,
+    is_cxl_io_completion_status_ur,
+)
+
+
+# Test ld_id
+# TODO: Test ld_id value from return (read) packets
+@pytest.mark.asyncio
+async def test_multi_logical_device_ld_id():
+    # Test 4 LDs
+    num_ld = 4
+    # Test routing to LD-ID 2
+    target_ld_id = 2
+    ld_size = 256 * MB
+    logger.info(f"[PyTest] Creating {num_ld} LDs, testing LD-ID routing to {target_ld_id}")
+
+    # Create MLD instance
+    cxl_connections = [CxlConnection() for _ in range(num_ld)]
+    mld = MultiLogicalDevice(
+        num_ld=num_ld,
+        port_index=1,
+        memory_sizes=[ld_size] * num_ld,
+        memory_files=[f"mld_mem{i}.bin" for i in range(num_ld)],
+        test_mode=True,
+        cxl_connections=cxl_connections,
+    )
+
+    # Start MLD pseudo server
+    async def handle_client(reader, writer):
+        global mld_pseudo_server_reader, mld_pseudo_server_packet_reader, mld_pseudo_server_writer  # pylint: disable=global-variable-undefined
+        mld_pseudo_server_reader = reader
+        mld_pseudo_server_packet_reader = PacketReader(reader, label="test_mmio")
+        mld_pseudo_server_writer = writer
+        assert mld_pseudo_server_writer is not None, "mld_pseudo_server_writer is NoneType"
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", 8000)
+    # This is cleaned up via 'server.wait_closed()' below
+    asyncio.create_task(server.serve_forever())
+
+    await server.start_serving()
+
+    # Setup CxlPacketProcessor for MLD - connect to 127.0.0.1:8000
+    mld_packet_processor_reader, mld_packet_processor_writer = await asyncio.open_connection(
+        "127.0.0.1", 8000
+    )
+    mld_packet_processor = CxlPacketProcessor(
+        mld_packet_processor_reader,
+        mld_packet_processor_writer,
+        cxl_connections,
+        CXL_COMPONENT_TYPE.LD,
+        label="ClientPortMld",
+    )
+    mld_packet_processor_task = create_task(mld_packet_processor.run())
+
+    memory_base_address = 0xFE000000
+    bar_size = 131072  # Empirical value
+
+    async def configure_bar(
+        target_ld_id: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        packet_reader = PacketReader(reader, label="configure_bar")
+        packet_writer = writer
+
+        logger.info("[PyTest] Settting Bar Address")
+        # NOTE: Test Config Space Type0 Write - BAR WRITE
+        packet = CxlIoCfgWrPacket.create(
+            create_bdf(0, 0, 0),
+            0x10,
+            4,
+            value=memory_base_address,
+            is_type0=True,
+            ld_id=target_ld_id,
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_sc(packet)
+
+    async def test_config_space(
+        target_ld_id: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        # pylint: disable=duplicate-code
+        packet_reader = PacketReader(reader, label="test_config_space")
+        packet_writer = writer
+
+        # NOTE: Test Config Space Type0 Read - VID/DID
+        logger.info("[PyTest] Testing Config Space Type0 Read (VID/DID)")
+        packet = CxlIoCfgRdPacket.create(
+            create_bdf(0, 0, 0), 0, 4, is_type0=True, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_sc(packet)
+        cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
+        assert cpld_packet.data == (EEUM_VID | (SW_MLD_DID << 16))
+
+        # NOTE: Test Config Space Type0 Write - BAR WRITE
+        logger.info("[PyTest] Testing Config Space Type0 Write (BAR)")
+        packet = CxlIoCfgWrPacket.create(
+            create_bdf(0, 0, 0), 0x10, 4, 0xFFFFFFFF, is_type0=True, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_sc(packet)
+
+        # NOTE: Test Config Space Type0 Read - BAR READ
+        logger.info("[PyTest] Testing Config Space Type0 Read (BAR)")
+        packet = CxlIoCfgRdPacket.create(
+            create_bdf(0, 0, 0), 0x10, 4, is_type0=True, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_sc(packet)
+        cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
+        size = 0xFFFFFFFF - cpld_packet.data + 1
+        assert size == bar_size
+
+        # NOTE: Test Config Space Type1 Read - VID/DID: Expect UR
+        logger.info("[PyTest] Testing Config Space Type1 Read - Expect UR")
+        packet = CxlIoCfgRdPacket.create(
+            create_bdf(0, 0, 0), 0, 4, is_type0=False, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_ur(packet)
+
+        # NOTE: Test Config Space Type1 Write - BAR WRITE: Expect UR
+        logger.info("[PyTest] Testing Config Space Type1 Write - Expect UR")
+        packet = CxlIoCfgWrPacket.create(
+            create_bdf(0, 0, 0), 0x10, 4, 0xFFFFFFFF, is_type0=False, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        assert is_cxl_io_completion_status_ur(packet)
+
+    async def setup_hdm_decoder(
+        num_ld: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        # pylint: disable=duplicate-code
+        packet_reader = PacketReader(reader, label="setup_hdm_decoder")
+        packet_writer = writer
+
+        register_offset = memory_base_address + 0x1014
+        decoder_index = 0
+        hpa_base = 0x0
+        hpa_size = ld_size
+        dpa_skip = 0
+        interleaving_granularity = 0
+        interleaving_way = 0
+
+        for ld_id in range(num_ld):
+            # NOTE: Test Config Space Type0 Write - BAR WRITE
+            packet = CxlIoCfgWrPacket.create(
+                create_bdf(0, 0, 0),
+                0x10,
+                4,
+                value=register_offset,
+                is_type0=True,
+                ld_id=ld_id,
+            )
+            packet_writer.write(bytes(packet))
+            await packet_writer.drain()
+            packet = await packet_reader.get_packet()
+            assert is_cxl_io_completion_status_sc(packet)
+            assert packet.tlp_prefix.ld_id == ld_id
+
+            # Use HPA = DPA
+            logger.info(f"[PyTest] Setting up HDM Decoder for {ld_id}")
+
+            dpa_skip_low_offset = 0x20 * decoder_index + 0x24 + register_offset
+            dpa_skip_high_offset = 0x20 * decoder_index + 0x28 + register_offset
+            dpa_skip_low = dpa_skip & 0xFFFFFFFF
+            dpa_skip_high = (dpa_skip >> 32) & 0xFFFFFFFF
+
+            packet = CxlIoMemWrPacket.create(dpa_skip_low_offset, 4, dpa_skip_low, ld_id=ld_id)
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            packet = CxlIoMemWrPacket.create(dpa_skip_high_offset, 4, dpa_skip_high, ld_id=ld_id)
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            decoder_base_low_offset = 0x20 * decoder_index + 0x10 + register_offset
+            decoder_base_high_offset = 0x20 * decoder_index + 0x14 + register_offset
+            decoder_size_low_offset = 0x20 * decoder_index + 0x18 + register_offset
+            decoder_size_high_offset = 0x20 * decoder_index + 0x1C + register_offset
+            decoder_control_register_offset = 0x20 * decoder_index + 0x20 + register_offset
+
+            commit = 1
+
+            decoder_base_low = hpa_base & 0xFFFFFFFF
+            decoder_base_high = (hpa_base >> 32) & 0xFFFFFFFF
+            decoder_size_low = hpa_size & 0xFFFFFFFF
+            decoder_size_high = (hpa_size >> 32) & 0xFFFFFFFF
+
+            decoder_control = (
+                interleaving_granularity & 0xF | (interleaving_way & 0xF) << 4 | commit << 9
+            )
+
+            packet = CxlIoMemWrPacket.create(
+                decoder_base_low_offset, 4, decoder_base_low, ld_id=ld_id
+            )
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            packet = CxlIoMemWrPacket.create(
+                decoder_base_high_offset, 4, decoder_base_high, ld_id=ld_id
+            )
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            packet = CxlIoMemWrPacket.create(
+                decoder_size_low_offset, 4, decoder_size_low, ld_id=ld_id
+            )
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            packet = CxlIoMemWrPacket.create(
+                decoder_size_high_offset, 4, decoder_size_high, ld_id=ld_id
+            )
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            packet = CxlIoMemWrPacket.create(
+                decoder_control_register_offset, 4, decoder_control, ld_id=ld_id
+            )
+            writer.write(bytes(packet))
+            await writer.drain()
+
+            register_offset += 0x200000
+
+        logger.info("[PyTest] HDM Decoder setup complete")
+
+    async def test_mmio(
+        target_ld_id: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        packet_reader = PacketReader(reader, label="test_mmio")
+        packet_writer = writer
+
+        logger.info("[PyTest] Accessing MMIO register")
+
+        # NOTE: Write 0xDEADBEEF
+        data = 0xDEADBEEF
+        packet = CxlIoMemWrPacket.create(memory_base_address, 4, data=data, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+
+        # NOTE: Confirm 0xDEADBEEF is written
+        packet = CxlIoMemRdPacket.create(memory_base_address, 4, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert is_cxl_io_completion_status_sc(packet)
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
+        logger.info(f"[PyTest] Received CXL.io packet: {cpld_packet}")
+        assert cpld_packet.data == data
+
+        # NOTE: Write OOB (Upper Boundary), Expect No Error
+        packet = CxlIoMemWrPacket.create(
+            memory_base_address + bar_size, 4, data=data, ld_id=target_ld_id
+        )
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+
+        # NOTE: Write OOB (Lower Boundary), Expect No Error
+        packet = CxlIoMemWrPacket.create(memory_base_address - 4, 4, data=data, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+
+        # NOTE: Read OOB (Upper Boundary), Expect 0
+        packet = CxlIoMemRdPacket.create(memory_base_address + bar_size, 4, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert is_cxl_io_completion_status_sc(packet)
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
+        assert cpld_packet.data == 0
+
+        # NOTE: Read OOB (Lower Boundary), Expect 0
+        packet = CxlIoMemRdPacket.create(memory_base_address - 4, 4, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert is_cxl_io_completion_status_sc(packet)
+        assert packet.tlp_prefix.ld_id == target_ld_id
+        cpld_packet = cast(CxlIoCompletionWithDataPacket, packet)
+        assert cpld_packet.data == 0
+
+    async def send_packets(
+        target_ld_id: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        packet_reader = PacketReader(reader, label="send_packets")
+        packet_writer = writer
+
+        target_address = 0x80
+        target_data = 0xDEADBEEF
+
+        logger.info("[PyTest] Sending CXL.mem request packets from client")
+        packet = CxlMemMemWrPacket.create(target_address, target_data, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+        packet = await packet_reader.get_packet()
+        assert packet.s2mndr_header.ld_id == target_ld_id
+
+        packet = CxlMemMemRdPacket.create(target_address, ld_id=target_ld_id)
+        packet_writer.write(bytes(packet))
+        await packet_writer.drain()
+
+        logger.info("[PyTest] Checking CXL.mem request packets received from server")
+        packet = await packet_reader.get_packet()
+        assert packet.s2mdrs_header.ld_id == target_ld_id
+        mem_packet = cast(CxlMemMemRdPacket, packet)
+        logger.info(f"[PyTest] Received CXL.mem packet: {hex(mem_packet.data)}")
+        assert mem_packet.data == target_data
+
+        # Check MLD bin file
+        logger.info("[PyTest] Checking MLD bin file")
+        with open(f"mld_mem{target_ld_id}.bin", "rb") as f:
+            f.seek(target_address)
+            data = f.read(4)
+            value = struct.unpack("<I", data)[0]
+            assert value == target_data
+
+    # Start MLD
+    mld_task = create_task(mld.run())
+
+    # Start the tests
+    await mld.wait_for_ready()
+    # Test MLD LD-ID handling
+    await setup_hdm_decoder(num_ld, mld_pseudo_server_reader, mld_pseudo_server_writer)
+    await configure_bar(target_ld_id, mld_pseudo_server_reader, mld_pseudo_server_writer)
+    await test_config_space(target_ld_id, mld_pseudo_server_reader, mld_pseudo_server_writer)
+    await test_mmio(target_ld_id, mld_pseudo_server_reader, mld_pseudo_server_writer)
+    await send_packets(target_ld_id, mld_pseudo_server_reader, mld_pseudo_server_writer)
+
+    # Stop all devices
+    await mld_packet_processor.stop()
+    await mld_packet_processor_task
+    await mld.stop()
+    await mld_task
+
+    # Stop pseudo server
+    server.close()
+    await server.wait_closed()


### PR DESCRIPTION
**[Code coverage]**
- [x] opencxl/cxl/component/cxl_packet_processor.py:208-212 CPL, CPLD packet LD-ID handling (Gwangin)

(This is a switch-related change, remove it from this PR for now.)

In `_process_incoming_packets()`, our test case triggers `is_cfg()` but not `is_cpl(d)()`. We're not sure if this is an intended MLD behavior.

- [x] opencxl/pci/component/config_space_manager.py:120 ld_id code not triggered in _process_cxl_io_cfg_rd() (Juhyung)

**[Failing test]**
- [x] tests/test_cxl_image_classification_host.py (Juhyung)

**[Misc]**
- [x] Minor lint complaints with duplicate similar lines (Chanwoo)
- [x] HDM decoder should be setup using CXL.io/MMIO instead of directly calling internal members
- [x] Remove non-MLD "device specific" code (e.g., switch/port code) (Separated to `mld-dev-wip` branch)
- [x] Sanity-check all the "ACK" packets

**[Unrelated]**
- Random failure (race conditions?) on `tests/test_cxl_host.py::test_cxl_host_type3_ete`