### PR TITLE
Add Test Code for UI Dev

### DIFF
--- a/opencxl/cxl/cci/fabric_manager/virtual_switch/get_virtual_cxl_switch_info.py
+++ b/opencxl/cxl/cci/fabric_manager/virtual_switch/get_virtual_cxl_switch_info.py
@@ -162,7 +162,9 @@ class VcsInfoBlock:
             "vcsState": self.vcs_state.name,
             "uspId": self.usp_id,
             "numOfVppbs": self.num_of_vppbs,
-            "vppbs": [ppb_info.to_dict() for ppb_info in self.ppb_info_list],
+            # TODO: make the same change in v0.4-dev
+            # The naming for this should be coherent to the class def
+            "ppb_info_list": [ppb_info.to_dict() for ppb_info in self.ppb_info_list],
         }
 
 


### PR DESCRIPTION
This PR adds some code to create a simulated binding information backend for UI development. The UI development team can work on UI development without waiting for the implementation of the real MCTP/CCI protocol.

There are also 2 TODOs that need to be addressed in future v0.4-dev.