### PR TITLE
Fix IrqManager and ShortMsgConn

### DIFF
--- a/opencxl/cxl/component/irq_manager.py
+++ b/opencxl/cxl/component/irq_manager.py
@@ -5,10 +5,10 @@
  See LICENSE for details.
 """
 
-from opencxl.cxl.component.short_msg_conn import ShortMsg, ShortMsgConn
+from opencxl.cxl.component.short_msg_conn import ShortMsgBase, ShortMsgConn
 
 
-class Irq(ShortMsg):
+class Irq(ShortMsgBase):
     NULL = 0x00
 
     # Host-side file ready to be read by device using CXL.cache
@@ -39,4 +39,12 @@ class IrqManager(ShortMsgConn):
         server: bool = False,
         device_id: int = 0,
     ):
-        super().__init__(f"{device_name}:IrqHandler", addr, port, server, device_id, msg_width=1)
+        super().__init__(
+            f"{device_name}:IrqHandler",
+            addr,
+            port,
+            server,
+            device_id,
+            msg_width=1,
+            msg_type=Irq,
+        )

--- a/opencxl/cxl/component/short_msg_conn.py
+++ b/opencxl/cxl/component/short_msg_conn.py
@@ -28,10 +28,6 @@ class ShortMsgBase(Enum):
     pass
 
 
-class ShortMsgPlaceholder(ShortMsgBase):
-    NULL = 0x00
-
-
 class ShortMsgConn(RunnableComponent):
     _msg_to_interrupt_event: dict[int, dict[ShortMsgBase, Callable]]
     _callbacks: list[Callable]
@@ -45,7 +41,7 @@ class ShortMsgConn(RunnableComponent):
         server: bool = False,
         device_id: int = 0,
         msg_width: int = 2,
-        msg_type=ShortMsgPlaceholder,
+        msg_type=ShortMsgBase,
     ):
         super().__init__(f"{device_name}:ShortMsgConn")
         self._addr = addr
@@ -65,15 +61,6 @@ class ShortMsgConn(RunnableComponent):
         self._device_id = device_id
         self._run_status = False
         self._msg_tasks: list[Task] = []
-        if msg_type == ShortMsgPlaceholder:
-            logger.warning(
-                self._create_message("You are using the ShortMsgPlaceholder for ShortMsgConn data.")
-            )
-            logger.warning(
-                self._create_message(
-                    "Please create a custom class extending ShortMsgBase class for custom messages."
-                )
-            )
         self._msg_type = msg_type
 
     def register_interrupt_handler(


### PR DESCRIPTION
The previous code for ShortMsgConn does not address the cases where a custom ShortMsgConn can have different types of customized data (e.g., Irq for IrqManager). The ShortMsgConn instance will stall when a message is received from the remote end because it is unable to cast the data into the given customized data type.

This commit fixes the issues above.