### PR TITLE
Fix Broken Packet Definition

### DIFF
--- a/opencxl/cxl/component/mctp/mctp_cci_api_client.py
+++ b/opencxl/cxl/component/mctp/mctp_cci_api_client.py
@@ -128,7 +128,7 @@ class MctpCciApiClient(RunnableComponent):
         header.message_category = CCI_MCTP_MESSAGE_CATEGORY.REQUEST
         header.command_opcode = request.opcode
         header.set_message_payload_length(len(request.payload))
-        message_packet = CciMessagePacket(header, request.payload)
+        message_packet = CciMessagePacket.create(header, request.payload)
         return message_packet
 
     async def _wait_for_background_operation(self) -> CCI_RETURN_CODE:

--- a/opencxl/cxl/component/mctp/mctp_cci_executor.py
+++ b/opencxl/cxl/component/mctp/mctp_cci_executor.py
@@ -47,7 +47,7 @@ class MctpCciExecutor(RunnableComponent):
         header.background_operation = 1 if response.bo_flag else 0
         header.return_code = response.return_code
         header.vendor_specific_extended_status = response.vendor_specific_status
-        response_packet = CciMessagePacket(header, response.payload)
+        response_packet = CciMessagePacket.create(header, response.payload)
         await self._mctp_connection.ep_to_controller.put(response_packet)
 
     async def _process_incoming_requests(self):
@@ -88,7 +88,7 @@ class MctpCciExecutor(RunnableComponent):
         header.message_category = CCI_MCTP_MESSAGE_CATEGORY.REQUEST
         header.set_message_payload_length(len(request.payload))
         header.command_opcode = request.opcode
-        message_packet = CciMessagePacket(header, request.payload)
+        message_packet = CciMessagePacket.create(header, request.payload)
         opcode_str = get_opcode_string(request.opcode)
         logger.debug(self._create_message(f"Sending {opcode_str}"))
         await self._mctp_connection.ep_to_controller.put(message_packet)

--- a/opencxl/cxl/component/mctp/mctp_packet_processor.py
+++ b/opencxl/cxl/component/mctp/mctp_packet_processor.py
@@ -65,7 +65,7 @@ class MctpPacketProcessor(RunnableComponent):
                 break
             cci_packet = cast(CciMessagePacket, packet)
             self._writer.write(bytes(cci_packet.header))
-            self._writer.write(cci_packet.payload)
+            self._writer.write(cci_packet.data.to_bytes(cci_packet.get_payload_size(), "little"))
             await self._writer.drain()
         logger.debug(self._create_message("Stopped outgoing packet processor"))
 

--- a/opencxl/cxl/component/mctp/mctp_packet_reader.py
+++ b/opencxl/cxl/component/mctp/mctp_packet_reader.py
@@ -44,10 +44,10 @@ class MctpPacketReader(LabeledComponent):
         message_header = await self._get_cci_message_header()
         payload_length = message_header.get_message_payload_length()
         if payload_length > 0:
-            message_payload = await self._read_payload(payload_length)
+            payload_data = await self._read_payload(payload_length)
         else:
-            message_payload = bytes()
-        packet = CciMessagePacket(header=message_header, payload=message_payload)
+            payload_data = bytes()
+        packet = CciMessagePacket.create(header=message_header, data=payload_data)
         return packet
 
     async def _get_cci_message_header(self) -> CciMessageHeaderPacket:

--- a/opencxl/cxl/transport/transaction.py
+++ b/opencxl/cxl/transport/transaction.py
@@ -1906,7 +1906,7 @@ CCI_HEADER_START = SYSTEM_HEADER_END + 1
 CCI_HEADER_END = CCI_HEADER_START + CciHeaderPacket.get_size() - 1
 
 
-class CciMessagePacket(UnalignedBitStructure):
+class CciMessageBasePacket(UnalignedBitStructure):
     header: CciMessageHeaderPacket
     data: int
 
@@ -1925,6 +1925,16 @@ class CciMessagePacket(UnalignedBitStructure):
 
     def get_payload_size(self) -> int:
         return self.header.get_message_payload_length()
+
+
+class CciMessagePacket(CciMessageBasePacket):
+    @staticmethod
+    def create(header: CciMessageHeaderPacket, data: bytes) -> "CciMessagePacket":
+        packet = CciMessagePacket()
+        packet.set_dynamic_field_length(len(data))
+        packet.header = header
+        packet.data = int.from_bytes(data, "little")
+        return packet
 
 
 CCI_FIELD_START = CCI_HEADER_END + 1


### PR DESCRIPTION
This commit fixes the issues caused by the new definition of the CciMessagePacket. Some existing code was built based on the older version of the packet definition. Those codes are now up to date.