### PR TITLE
Implement traceback check for all exceptions

### DIFF
--- a/linter/exception_logger.py
+++ b/linter/exception_logger.py
@@ -1,0 +1,97 @@
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+import astroid
+
+
+class ExceptionLoggerChecker(BaseChecker):
+    name = 'try-except-logger'
+    msgs = {
+        'E9001': (
+            'Missing logger.error with traceback in except block',
+            'missing-exception-logger-error',
+            'All except blocks must log the error using logger.error with traceback.format_exc().'
+        ),
+    }
+    options = ()
+
+    def __init__(self, linter=None):
+        super().__init__(linter)
+
+    def visit_try(self, node):
+        # Skip non-opencxl files
+        if not node.root().name.startswith('opencxl.'):
+            return
+
+        for handler in node.handlers:
+            if self._is_whitelisted_exceptions(handler):
+                continue
+
+            # If the except block contains a raise statement, skip
+            if any(self._contains_raise(stmt) for stmt in handler.body):
+                continue
+
+            if not any(self._contains_logger_error(stmt) for stmt in handler.body):
+                self.add_message('missing-exception-logger-error', node=node)
+
+    def _is_whitelisted_exceptions(self, handler):
+        """
+        Checks if the except handler is specifically for `asyncio.exceptions.TimeoutError`.
+        """
+        whitelisted_exceptions = ['TimeoutError', 'CancelledError', 'ConnectionClosed']
+        if handler.type:
+            for exception in whitelisted_exceptions:
+                if isinstance(handler.type, astroid.Attribute) and handler.type.attrname == exception:
+                    return True
+                if isinstance(handler.type, astroid.Name) and handler.type.name == exception:
+                    return True
+        return False
+
+    def _contains_raise(self, node):
+        if isinstance(node, astroid.Raise):
+            return True
+        return any(self._contains_raise(child) for child in node.get_children())
+
+    def _contains_logger_error(self, node):
+        if isinstance(node, astroid.Expr) and isinstance(node.value, astroid.Call):
+            func = node.value.func
+            if (
+                isinstance(func, astroid.Attribute)
+                and func.attrname == 'error'
+                and isinstance(func.expr, astroid.Name)
+                and func.expr.name == 'logger'
+            ):
+                # Check all arguments for traceback.format_exc()
+                for arg in node.value.args:
+                    if self._contains_traceback_format_exc(arg):
+                        return True
+        return False
+
+    def _contains_traceback_format_exc(self, node):
+        if isinstance(node, astroid.Call):
+            func = node.func
+            # Check for traceback.format_exc()
+            if (
+                isinstance(func, astroid.Attribute)
+                and func.attrname == 'format_exc'
+                and isinstance(func.expr, astroid.Name)
+                and func.expr.name == 'traceback'
+            ):
+                return True
+            # Recursively check arguments of this call
+            return any(self._contains_traceback_format_exc(arg) for arg in node.args)
+        elif isinstance(node, astroid.BinOp) and node.op == '%':
+            # Handle old-style string formatting: "msg % args"
+            return any(self._contains_traceback_format_exc(child) for child in [node.left, node.right])
+        elif isinstance(node, astroid.JoinedStr):
+            # Handle f-strings by checking all values in the f-string
+            return any(self._contains_traceback_format_exc(value) for value in node.values)
+        elif isinstance(node, astroid.FormattedValue):
+            # If it's an f-string, check the value inside
+            return self._contains_traceback_format_exc(node.value)
+        elif isinstance(node, astroid.Call) or isinstance(node, astroid.Expr):
+            # Recursively check nested calls and expressions
+            return any(self._contains_traceback_format_exc(child) for child in node.get_children())
+        return False
+
+def register(linter: PyLinter) -> None:
+    linter.register_checker(ExceptionLoggerChecker(linter))

--- a/opencxl/apps/accelerator.py
+++ b/opencxl/apps/accelerator.py
@@ -10,6 +10,7 @@ from asyncio import CancelledError, gather, create_task, Event, sleep
 import glob
 from io import BytesIO
 import math
+import traceback
 from typing import cast
 import shutil
 from pathlib import Path
@@ -371,7 +372,7 @@ class MyType1Accelerator(RunnableComponent):
             logger.info(self._create_message("Done Model Training"))
             await self._irq_manager.send_irq_request(Irq.ACCEL_TRAINING_FINISHED)
         except CancelledError:
-            print(self._create_message("Runapp Cancelled"))
+            logger.error(self._create_message(f"Runapp Cancelled: {traceback.format_exc()}"))
             return
 
     async def _app_shutdown(self):

--- a/opencxl/apps/fabric_manager.py
+++ b/opencxl/apps/fabric_manager.py
@@ -70,8 +70,11 @@ class CxlFabricManager(RunnableComponent):
                 BindVppbRequestPayload(vcs_id=0, vppb_id=3, physical_port_id=4)
             )
         except Exception as e:
-            logger.debug(str(e))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
 
     async def _run(self):
         tasks = [

--- a/opencxl/cxl/component/cci_executor.py
+++ b/opencxl/cxl/component/cci_executor.py
@@ -62,8 +62,11 @@ class CciForegroundCommand(CciCommand):
         try:
             return await self._execute(request)
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
             response = CciResponse(bo_flag=False, return_code=CCI_RETURN_CODE.INTERNAL_ERROR)
             return response
 
@@ -80,8 +83,11 @@ class CciBackgroundCommand(CciCommand):
         try:
             return await self._execute(request, callback)
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
             await callback(100)
             response = CciResponse(return_code=CCI_RETURN_CODE.INTERNAL_ERROR)
             return response

--- a/opencxl/cxl/component/cxl_packet_processor.py
+++ b/opencxl/cxl/component/cxl_packet_processor.py
@@ -14,6 +14,7 @@ from asyncio import (
 )
 from dataclasses import dataclass
 from enum import StrEnum, IntEnum
+import traceback
 from typing import cast, Optional, Dict, Union, List
 
 from opencxl.util.logger import logger
@@ -295,7 +296,11 @@ class CxlPacketProcessor(RunnableComponent):
                     logger.debug(self._create_message(message))
                     raise Exception(message)
             except Exception as e:
-                logger.debug(self._create_message(str(e)))
+                logger.error(
+                    self._create_message(
+                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                    )
+                )
                 notification_packet = BaseSidebandPacket.create(
                     SIDEBAND_TYPES.CONNECTION_DISCONNECTED
                 )

--- a/opencxl/cxl/component/host_manager_conn.py
+++ b/opencxl/cxl/component/host_manager_conn.py
@@ -170,6 +170,7 @@ class HostManagerConnClient(RunnableComponent):
         self._event = asyncio.Event()
         self._ws = None
 
+    # pylint: disable=missing-exception-logger-error
     async def _open_connection(self, port: int):
         logger.info(self._create_message("Connecting to HostManager"))
         while True:

--- a/opencxl/cxl/component/packet_reader.py
+++ b/opencxl/cxl/component/packet_reader.py
@@ -64,13 +64,15 @@ class PacketReader(LabeledComponent):
             self._task = create_task(self._get_packet_in_task())
             packet = await self._task
         except Exception as e:
-            logger.debug(self._create_message(str(e)))
-            if str(e) != "Connection disconnected":
-                logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
+            )
             raise Exception("PacketReader is aborted") from e
-        except CancelledError as exc:
-            logger.debug(self._create_message("Aborted"))
-            raise Exception("PacketReader is aborted") from exc
+        except CancelledError as e:
+            logger.error(
+                self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
+            )
+            raise Exception("PacketReader is aborted") from e
         finally:
             self._task = None
         return packet

--- a/opencxl/cxl/component/switch_connection_client.py
+++ b/opencxl/cxl/component/switch_connection_client.py
@@ -98,6 +98,7 @@ class SwitchConnectionClient(RunnableComponent):
     def get_port_index(self):
         return self._port_index
 
+    # pylint: disable=missing-exception-logger-error
     async def _run(self):
         if self._retry:
             time_out = 120

--- a/opencxl/cxl/component/switch_connection_manager.py
+++ b/opencxl/cxl/component/switch_connection_manager.py
@@ -82,7 +82,11 @@ class SwitchConnectionManager(RunnableComponent):
             await self._change_status_to_running()
             await self._server_task
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
         except CancelledError:
             logger.info(self._create_message("Stopped TCP server"))
 
@@ -109,8 +113,11 @@ class SwitchConnectionManager(RunnableComponent):
                 await self._update_connection_status(port_index, connected=True)
                 await self._start_packet_processor(reader, writer, port_index)
             except Exception as e:
-                logger.warning(self._create_message(str(e)))
-                logger.debug(traceback.format_exc())
+                logger.error(
+                    self._create_message(
+                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                    )
+                )
 
             if port_index is None:
                 await self._send_rejection(writer)
@@ -135,7 +142,11 @@ class SwitchConnectionManager(RunnableComponent):
         try:
             await writer.wait_closed()
         except Exception as e:
-            logger.warning(self._create_message(str(e)))
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
 
         if port_index is None:
             logger.info(self._create_message("Closed connection"))

--- a/opencxl/cxl/environment/environment.py
+++ b/opencxl/cxl/environment/environment.py
@@ -22,6 +22,8 @@ from opencxl.cxl.device.config.logical_device import (
     MultiLogicalDeviceConfig,
 )
 
+# pylint: disable=missing-exception-logger-error
+
 
 @dataclass
 class CxlEnvironment:

--- a/opencxl/cxl/transport/socket_server.py
+++ b/opencxl/cxl/transport/socket_server.py
@@ -5,6 +5,7 @@
  See LICENSE for details.
 """
 
+import traceback
 from typing import List
 import socket
 from opencxl.util.logger import logger
@@ -29,7 +30,7 @@ class SocketServerTransport:
             connection.setblocking(False)
             self._incoming_connections.add(connection)
         except Exception as e:
-            logger.error(f"check_incoming_connections error: {e}")
+            logger.error(f"check_incoming_connections error: {str(e)}: {traceback.format_exc()}")
 
     def get_incoming_connections(self) -> List[socket.socket]:
         return list(self._incoming_connections)
@@ -49,7 +50,7 @@ class SocketServerTransport:
             error_code = connection.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
             return error_code == 0
         except Exception as e:
-            logger.error(f"is_active_connection error: {e}")
+            logger.error(f"is_active_connection error: {str(e)}: {traceback.format_exc()}")
             return False
 
     def unclaim_connection(self, connection: socket.socket) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,13 @@ disable = [
   "disallowed-name",
   "too-many-statements",
 ]
+enable = [
+  "missing-exception-logger-error",
+]
 jobs = 4
+
+[tool.pylint.MASTER]
+load-plugins = "linter.exception_logger"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Some of the exceptions were caught and printed sliently.

Make sure these are printed out very noisily so that we don't waste time hunting it down...