### PR TITLE
Print verbose tracebacks for all exceptions

### DIFF
--- a/opencxl/apps/accelerator.py
+++ b/opencxl/apps/accelerator.py
@@ -10,6 +10,7 @@ from asyncio import CancelledError, gather, create_task, Event, sleep
 import glob
 from io import BytesIO
 import math
+import traceback
 from typing import cast
 import shutil
 from pathlib import Path
@@ -369,7 +370,7 @@ class MyType1Accelerator(RunnableComponent):
             logger.info(self._create_message("Done Model Training"))
             await self._irq_manager.send_irq_request(Irq.ACCEL_TRAINING_FINISHED)
         except CancelledError:
-            print(self._create_message("Runapp Cancelled"))
+            logger.error(self._create_message(f"Runapp Cancelled: {traceback.format_exc()}"))
             return
 
     def _app_shutdown(self):

--- a/opencxl/apps/fabric_manager.py
+++ b/opencxl/apps/fabric_manager.py
@@ -86,8 +86,11 @@ class CxlFabricManager(RunnableComponent):
                 BindVppbRequestPayload(vcs_id=0, vppb_id=3, physical_port_id=4)
             )
         except Exception as e:
-            logger.debug(str(e))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
 
     async def _run(self):
         tasks = [

--- a/opencxl/cxl/component/cci_executor.py
+++ b/opencxl/cxl/component/cci_executor.py
@@ -62,8 +62,11 @@ class CciForegroundCommand(CciCommand):
         try:
             return await self._execute(request)
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
             response = CciResponse(bo_flag=False, return_code=CCI_RETURN_CODE.INTERNAL_ERROR)
             return response
 
@@ -80,8 +83,11 @@ class CciBackgroundCommand(CciCommand):
         try:
             return await self._execute(request, callback)
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
-            logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
             await callback(100)
             response = CciResponse(return_code=CCI_RETURN_CODE.INTERNAL_ERROR)
             return response

--- a/opencxl/cxl/component/cxl_packet_processor.py
+++ b/opencxl/cxl/component/cxl_packet_processor.py
@@ -14,6 +14,7 @@ from asyncio import (
 )
 from dataclasses import dataclass
 from enum import StrEnum, IntEnum
+import traceback
 from typing import cast, Optional, Dict, Union, List
 
 from opencxl.util.logger import logger
@@ -295,7 +296,11 @@ class CxlPacketProcessor(RunnableComponent):
                     logger.debug(self._create_message(message))
                     raise Exception(message)
             except Exception as e:
-                logger.debug(self._create_message(str(e)))
+                logger.error(
+                    self._create_message(
+                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                    )
+                )
                 notification_packet = BaseSidebandPacket.create(
                     SIDEBAND_TYPES.CONNECTION_DISCONNECTED
                 )

--- a/opencxl/cxl/component/packet_reader.py
+++ b/opencxl/cxl/component/packet_reader.py
@@ -64,13 +64,15 @@ class PacketReader(LabeledComponent):
             self._task = create_task(self._get_packet_in_task())
             packet = await self._task
         except Exception as e:
-            logger.debug(self._create_message(str(e)))
-            if str(e) != "Connection disconnected":
-                logger.debug(traceback.format_exc())
+            logger.error(
+                self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
+            )
             raise Exception("PacketReader is aborted") from e
-        except CancelledError as exc:
-            logger.debug(self._create_message("Aborted"))
-            raise Exception("PacketReader is aborted") from exc
+        except CancelledError as e:
+            logger.error(
+                self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
+            )
+            raise Exception("PacketReader is aborted") from e
         finally:
             self._task = None
         return packet

--- a/opencxl/cxl/component/switch_connection_manager.py
+++ b/opencxl/cxl/component/switch_connection_manager.py
@@ -82,7 +82,11 @@ class SwitchConnectionManager(RunnableComponent):
             await self._change_status_to_running()
             await self._server_task
         except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
         except CancelledError:
             logger.info(self._create_message("Stopped TCP server"))
 
@@ -113,8 +117,11 @@ class SwitchConnectionManager(RunnableComponent):
                 await self._update_connection_status(port_index, connected=True)
                 await self._start_packet_processor(reader, writer, port_index)
             except Exception as e:
-                logger.warning(self._create_message(str(e)))
-                logger.debug(traceback.format_exc())
+                logger.error(
+                    self._create_message(
+                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                    )
+                )
 
             if port_index is None:
                 await self._send_rejection(writer)
@@ -139,7 +146,11 @@ class SwitchConnectionManager(RunnableComponent):
         try:
             await writer.wait_closed()
         except Exception as e:
-            logger.warning(self._create_message(str(e)))
+            logger.error(
+                self._create_message(
+                    f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
 
         if port_index is None:
             logger.info(self._create_message("Closed connection"))

--- a/opencxl/cxl/transport/socket_server.py
+++ b/opencxl/cxl/transport/socket_server.py
@@ -5,6 +5,7 @@
  See LICENSE for details.
 """
 
+import traceback
 from typing import List
 import socket
 from opencxl.util.logger import logger
@@ -29,7 +30,7 @@ class SocketServerTransport:
             connection.setblocking(False)
             self._incoming_connections.add(connection)
         except Exception as e:
-            logger.error(f"check_incoming_connections error: {e}")
+            logger.error(f"check_incoming_connections error: {str(e)}: {traceback.format_exc()}")
 
     def get_incoming_connections(self) -> List[socket.socket]:
         return list(self._incoming_connections)
@@ -49,7 +50,7 @@ class SocketServerTransport:
             error_code = connection.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
             return error_code == 0
         except Exception as e:
-            logger.error(f"is_active_connection error: {e}")
+            logger.error(f"is_active_connection error: {str(e)}: {traceback.format_exc()}")
             return False
 
     def unclaim_connection(self, connection: socket.socket) -> bool:


### PR DESCRIPTION
Some of the exceptions were caught and printed sliently.

Make sure these are printed out very noisily so that we don't waste time hunting it down...