### PR TITLE
Partially revert "Print verbose tracebacks for all exceptions (#146)"

### DIFF
--- a/opencxl/cxl/component/cxl_packet_processor.py
+++ b/opencxl/cxl/component/cxl_packet_processor.py
@@ -14,7 +14,6 @@ from asyncio import (
 )
 from dataclasses import dataclass
 from enum import StrEnum, IntEnum
-import traceback
 from typing import cast, Optional, Dict, Union, List
 
 from opencxl.util.logger import logger
@@ -296,11 +295,7 @@ class CxlPacketProcessor(RunnableComponent):
                     logger.debug(self._create_message(message))
                     raise Exception(message)
             except Exception as e:
-                logger.error(
-                    self._create_message(
-                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
-                    )
-                )
+                logger.debug(self._create_message(str(e)))
                 notification_packet = BaseSidebandPacket.create(
                     SIDEBAND_TYPES.CONNECTION_DISCONNECTED
                 )

--- a/opencxl/cxl/component/packet_reader.py
+++ b/opencxl/cxl/component/packet_reader.py
@@ -68,11 +68,9 @@ class PacketReader(LabeledComponent):
                 self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
             )
             raise Exception("PacketReader is aborted") from e
-        except CancelledError as e:
-            logger.error(
-                self._create_message(f"get_packet() error: {str(e)}, {traceback.format_exc()}")
-            )
-            raise Exception("PacketReader is aborted") from e
+        except CancelledError as exc:
+            logger.debug(self._create_message("Aborted"))
+            raise Exception("PacketReader is aborted") from exc
         finally:
             self._task = None
         return packet


### PR DESCRIPTION
This partially reverts commit 1588626a905baee866c66a9b0358028fec366110 and turns normal exceptions back to debug messages.