### PR TITLE
Replace multiple system-calls behind CxlMemoryDeviceComponent with mmap

### DIFF
--- a/opencis/cxl/component/cxl_memory_device_component.py
+++ b/opencis/cxl/component/cxl_memory_device_component.py
@@ -7,7 +7,6 @@ See LICENSE for details.
 
 from dataclasses import dataclass
 from enum import IntEnum
-import os
 import time
 from typing import TypedDict, List, Optional
 
@@ -65,28 +64,6 @@ from opencis.cxl.config_space.doe.cdat import (
 )
 
 SIZE_256MB = 256 * 1024 * 1024
-
-
-class CharDriverAccessor:
-    def __init__(self, filename: str, size: int):
-        self.filename = filename
-        self.size = size
-
-    async def write(self, offset: int, data: int, size: int):
-        # TODO: Check for OOB and use asyncio
-        data_bytes = data.to_bytes(size, "little")
-        fd = os.open(self.filename, os.O_WRONLY, 0o644)
-        os.lseek(fd, offset, os.SEEK_SET)
-        os.write(fd, data_bytes)
-        os.close(fd)
-
-    async def read(self, offset: int, size: int) -> int:
-        # TODO: Check for OOB and use asyncio
-        fd = os.open(self.filename, os.O_RDONLY)
-        os.lseek(fd, offset, os.SEEK_SET)
-        data = os.read(fd, size)
-        os.close(fd)
-        return int.from_bytes(data, "little")
 
 
 class MemoryDeviceIdentity(UnalignedBitStructure):
@@ -225,9 +202,7 @@ class CxlMemoryDeviceComponent(CxlDeviceComponent):
         self._hdm_decoder_manager = DeviceHdmDecoderManager(hdm_decoder_capabilities, label=label)
         if memory_size is None:
             memory_size = self._identity.get_total_capacity() // SIZE_256MB
-        if "/dev" in memory_file:
-            self._memory_accessor = CharDriverAccessor(memory_file, memory_size)
-        elif memory_file == "":
+        if memory_file == "":
             self._memory_accessor = None
         else:
             self._memory_accessor = FileAccessor(memory_file, memory_size)

--- a/opencis/cxl/device/cxl_type3_device.py
+++ b/opencis/cxl/device/cxl_type3_device.py
@@ -121,6 +121,7 @@ class CxlType3Device(RunnableComponent):
             identity,
             decoder_count=self._decoder_count,
             memory_file=self._memory_file,
+            memory_size=self._memory_size,
             label=self._label,
         )
 

--- a/opencis/util/accessor.py
+++ b/opencis/util/accessor.py
@@ -5,23 +5,27 @@ This software is licensed under the terms of the Revised BSD License.
 See LICENSE for details.
 """
 
+import mmap
+import os
+
 
 class FileAccessor:
     def __init__(self, filename: str, size: int):
-        self.filename = filename
-        with open(filename, "wb") as file:
-            file.write(b"\x00" * size)
-            file.flush()
+        with open(filename, "w+b") as file:
+            fd = file.fileno()
+            if os.path.isfile(filename):
+                os.posix_fallocate(fd, 0, size)
+            self._mmap = mmap.mmap(fd, size)
 
     async def write(self, offset: int, data: int, size: int):
-        # TODO: Check for OOB and use asyncio
-        with open(self.filename, "r+b") as file:
-            file.seek(offset)
-            file.write(data.to_bytes(size, byteorder="little"))
+        # TODO: Check for OOB
+        data_bytes = data.to_bytes(size, "little")
+        self._mmap[offset : offset + size] = data_bytes
 
     async def read(self, offset: int, size: int) -> int:
-        # TODO: Check for OOB and use asyncio
-        with open(self.filename, "rb") as file:
-            file.seek(offset)
-            data = file.read(size)
-            return int.from_bytes(data, byteorder="little")
+        # TODO: Check for OOB
+        data = self._mmap[offset : offset + size]
+        return int.from_bytes(data, "little")
+
+    def close(self):
+        self._mmap.close()


### PR DESCRIPTION
mmap is much cheaper than 3 system-calls.

 - Remove redundant CharDriverAccessor. It's no special anyways.
 - fallocate file to full length for proper mmap.