### PR TITLE
ci: rework to drop custom container

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -8,25 +8,59 @@ jobs:
   pytest:
     name: pytest
     runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/opencis/core-ci:0.2
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: Install Python packages via uv
-        run: uv python pin 3.13 && uv sync
+        uses: actions/checkout@v5
+      # Install directly using dpkg -x to avoid processing dpkg databases and triggers
+      - name: Install ccache
+        run: |
+          sudo apt install --download-only ccache
+          cd /
+          ls /var/cache/apt/archives/*.deb | sudo xargs -I {} dpkg -x {} /
+      - name: Setup ccache for Cython
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          prune-cache: false
+      - name: Sync uv
+        run: uv sync
       - name: Run pytest
         run: make test
   code-quality:
     name: code-quality
     runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/opencis/core-ci:0.2
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: Install Python packages via uv
-        run: uv python pin 3.13 && uv sync
+        uses: actions/checkout@v5
+      # Install directly using dpkg -x to avoid processing dpkg databases and triggers
+      - name: Install ccache
+        run: |
+          sudo apt install --download-only ccache
+          cd /
+          ls /var/cache/apt/archives/*.deb | sudo xargs -I {} dpkg -x {} /
+      - name: Setup ccache for Cython
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          prune-cache: false
+      - name: Sync uv
+        run: uv sync
       - name: Run pylint
         run: make lint
       - name: Run black

--- a/opencis/cxl/component/cxl_memory_device_component.py
+++ b/opencis/cxl/component/cxl_memory_device_component.py
@@ -7,7 +7,6 @@ See LICENSE for details.
 
 from dataclasses import dataclass
 from enum import IntEnum
-import os
 import time
 from typing import TypedDict, List, Optional
 
@@ -65,28 +64,6 @@ from opencis.cxl.config_space.doe.cdat import (
 )
 
 SIZE_256MB = 256 * 1024 * 1024
-
-
-class CharDriverAccessor:
-    def __init__(self, filename: str, size: int):
-        self.filename = filename
-        self.size = size
-
-    async def write(self, offset: int, data: int, size: int):
-        # TODO: Check for OOB and use asyncio
-        data_bytes = data.to_bytes(size, "little")
-        fd = os.open(self.filename, os.O_WRONLY, 0o644)
-        os.lseek(fd, offset, os.SEEK_SET)
-        os.write(fd, data_bytes)
-        os.close(fd)
-
-    async def read(self, offset: int, size: int) -> int:
-        # TODO: Check for OOB and use asyncio
-        fd = os.open(self.filename, os.O_RDONLY)
-        os.lseek(fd, offset, os.SEEK_SET)
-        data = os.read(fd, size)
-        os.close(fd)
-        return int.from_bytes(data, "little")
 
 
 class MemoryDeviceIdentity(UnalignedBitStructure):
@@ -225,9 +202,7 @@ class CxlMemoryDeviceComponent(CxlDeviceComponent):
         self._hdm_decoder_manager = DeviceHdmDecoderManager(hdm_decoder_capabilities, label=label)
         if memory_size is None:
             memory_size = self._identity.get_total_capacity() // SIZE_256MB
-        if "/dev" in memory_file:
-            self._memory_accessor = CharDriverAccessor(memory_file, memory_size)
-        elif memory_file == "":
+        if memory_file == "":
             self._memory_accessor = None
         else:
             self._memory_accessor = FileAccessor(memory_file, memory_size)

--- a/opencis/cxl/device/cxl_type3_device.py
+++ b/opencis/cxl/device/cxl_type3_device.py
@@ -121,6 +121,7 @@ class CxlType3Device(RunnableComponent):
             identity,
             decoder_count=self._decoder_count,
             memory_file=self._memory_file,
+            memory_size=self._memory_size,
             label=self._label,
         )
 

--- a/opencis/util/accessor.py
+++ b/opencis/util/accessor.py
@@ -5,23 +5,27 @@ This software is licensed under the terms of the Revised BSD License.
 See LICENSE for details.
 """
 
+import mmap
+import os
+
 
 class FileAccessor:
     def __init__(self, filename: str, size: int):
-        self.filename = filename
-        with open(filename, "wb") as file:
-            file.write(b"\x00" * size)
-            file.flush()
+        with open(filename, "w+b") as file:
+            fd = file.fileno()
+            if os.path.isfile(filename):
+                os.posix_fallocate(fd, 0, size)
+            self._mmap = mmap.mmap(fd, size)
 
     async def write(self, offset: int, data: int, size: int):
-        # TODO: Check for OOB and use asyncio
-        with open(self.filename, "r+b") as file:
-            file.seek(offset)
-            file.write(data.to_bytes(size, byteorder="little"))
+        # TODO: Check for OOB
+        data_bytes = data.to_bytes(size, "little")
+        self._mmap[offset : offset + size] = data_bytes
 
     async def read(self, offset: int, size: int) -> int:
-        # TODO: Check for OOB and use asyncio
-        with open(self.filename, "rb") as file:
-            file.seek(offset)
-            data = file.read(size)
-            return int.from_bytes(data, byteorder="little")
+        # TODO: Check for OOB
+        data = self._mmap[offset : offset + size]
+        return int.from_bytes(data, "little")
+
+    def close(self):
+        self._mmap.close()


### PR DESCRIPTION
- Drop custom container and use vanilla image for better maintainability
- Use ccache to cache and speed up Cython compilation
  (Installed directly via dpkg -x to avoid 30s delay from dpkg databases and triggers)
- Setup Python and uv with actions/setup-python, astral-sh/setup-uv to enable caching

These changes resolves insufficient space errors and improves CI time by 1-2 minutes.